### PR TITLE
KB-14009 | BE | Blended Program Enhancements | Learner TOC Page enhancement

### DIFF
--- a/src/main/java/org/sunbird/workflow/config/Configuration.java
+++ b/src/main/java/org/sunbird/workflow/config/Configuration.java
@@ -290,6 +290,9 @@ public class Configuration {
     @Value("${sunbird_time_zone}")
     private String sunbirdTimeZone;
 
+    @Value("${kafka.topics.bp.batch.stats}")
+    private String bpBatchStatsTopic;
+
     public String getAdminBlendedProgramEnrolEndPoint() {
         return adminBlendedProgramEnrolEndPoint;
     }
@@ -984,4 +987,13 @@ public class Configuration {
     public String getSunbirdTimeZone() { return sunbirdTimeZone; }
 
     public void setSunbirdTimeZone(String sunbirdTimeZone) { this.sunbirdTimeZone = sunbirdTimeZone; }
+
+
+    public String getBpBatchStatsTopic() {
+        return bpBatchStatsTopic;
+    }
+
+    public void setBpBatchStatsTopic(String bpBatchStatsTopic) {
+        this.bpBatchStatsTopic = bpBatchStatsTopic;
+    }
 }

--- a/src/main/java/org/sunbird/workflow/config/Configuration.java
+++ b/src/main/java/org/sunbird/workflow/config/Configuration.java
@@ -293,6 +293,12 @@ public class Configuration {
     @Value("${kafka.topics.bp.batch.stats}")
     private String bpBatchStatsTopic;
 
+    @Value("${bp.batch.stats.cache.ttl}")
+    private int bpBatchStatsCacheTtl;
+
+    @Value("${bp.batch.stats.cache.index}")
+    private int bpBatchStatsCacheIndex;
+
     public String getAdminBlendedProgramEnrolEndPoint() {
         return adminBlendedProgramEnrolEndPoint;
     }
@@ -995,5 +1001,21 @@ public class Configuration {
 
     public void setBpBatchStatsTopic(String bpBatchStatsTopic) {
         this.bpBatchStatsTopic = bpBatchStatsTopic;
+    }
+
+    public int getBpBatchStatsCacheTtl() {
+        return bpBatchStatsCacheTtl;
+    }
+
+    public void setBpBatchStatsCacheTtl(int bpBatchStatsCacheTtl) {
+        this.bpBatchStatsCacheTtl = bpBatchStatsCacheTtl;
+    }
+
+    public int getBpBatchStatsCacheIndex() {
+        return bpBatchStatsCacheIndex;
+    }
+
+    public void setBpBatchStatsCacheIndex(int bpBatchStatsCacheIndex) {
+        this.bpBatchStatsCacheIndex = bpBatchStatsCacheIndex;
     }
 }

--- a/src/main/java/org/sunbird/workflow/config/Constants.java
+++ b/src/main/java/org/sunbird/workflow/config/Constants.java
@@ -3,6 +3,7 @@ package org.sunbird.workflow.config;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public class Constants {
 
@@ -460,5 +461,10 @@ public class Constants {
 	public static final String PRIMARY_CATEGORY = "primaryCategory";
 	public static final String BLENDED_PROGRAM = "Blended Program";
 	public static final String WF_APPROVAL_TYPE = "wfApprovalType";
+
+	public static final String BP_BATCH_STATS_PREFIX = "bp:batch:enrollment:stats:";
+	public static final String BATCH_STATS_FIELD_PENDING = "pending";
+	public static final String BATCH_STATS_FIELD_WITHDRAWN = "withdrawn";
+	public static final Set<String> BATCH_STATS_TERMINAL_STATUSES = Set.of(APPROVED_STATE, REJECTED, WITHDRAWN, REMOVED);
 
 }

--- a/src/main/java/org/sunbird/workflow/config/Constants.java
+++ b/src/main/java/org/sunbird/workflow/config/Constants.java
@@ -465,6 +465,7 @@ public class Constants {
 	public static final String BP_BATCH_STATS_PREFIX = "bp:batch:enrollment:stats:";
 	public static final String BATCH_STATS_FIELD_PENDING = "pending";
 	public static final String BATCH_STATS_FIELD_WITHDRAWN = "withdrawn";
+	public static final String BATCH_STATS_FIELD_REJECTED = "rejected";
 	public static final Set<String> BATCH_STATS_TERMINAL_STATUSES = Set.of(APPROVED_STATE, REJECTED, WITHDRAWN, REMOVED);
 
 }

--- a/src/main/java/org/sunbird/workflow/config/WorkflowRedisCacheMgr.java
+++ b/src/main/java/org/sunbird/workflow/config/WorkflowRedisCacheMgr.java
@@ -2,38 +2,123 @@ package org.sunbird.workflow.config;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+import org.sunbird.workflow.postgres.repo.WfStatusRepo;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
+import java.util.Collections;
+import java.util.Map;
+
 @Component
 public class WorkflowRedisCacheMgr {
 
-        @Autowired
-        @Qualifier("jedisWorkflowPopulationPool")
-        private JedisPool jedisPool;
-
+    private final JedisPool jedisPool;
+    private final WfStatusRepo wfStatusRepo;
     private final Logger logger = LoggerFactory.getLogger(WorkflowRedisCacheMgr.class);
 
-        public void put(String key, String value, int ttl, int index) {
-            try (Jedis jedis = jedisPool.getResource()) {
-                jedis.select(index);
-                jedis.set(key, value);
-                jedis.expire(key, ttl);
-                logger.debug("Cache_key_value " + key + " is saved in redis");
-            } catch (Exception e) {
-                logger.error("An error occurred while saving data into Redis",e);
-            }
-        }
+    public WorkflowRedisCacheMgr(@Qualifier("jedisWorkflowPopulationPool") JedisPool jedisPool,
+                                 WfStatusRepo wfStatusRepo) {
+        this.jedisPool = jedisPool;
+        this.wfStatusRepo = wfStatusRepo;
+    }
 
-        public String get(String key, int index) {
-            try (Jedis jedis = jedisPool.getResource()) {
-                jedis.select(index);
-                return jedis.get(key);
-            } catch (Exception e) {
-                logger.error("An Error Occurred while getting content from cache", e);
-                return null;
+    public void put(String key, String value, int ttl, int index) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.select(index);
+            jedis.set(key, value);
+            jedis.expire(key, ttl);
+            logger.debug("Cache_key_value {} is saved in redis", key);
+        } catch (Exception e) {
+            logger.error("An error occurred while saving data into Redis", e);
+        }
+    }
+
+    public String get(String key, int index) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.select(index);
+            return jedis.get(key);
+        } catch (Exception e) {
+            logger.error("An Error Occurred while getting content from cache", e);
+            return null;
+        }
+    }
+
+    /**
+     * Lazy-initialises the batch stats Redis hash from the DB.
+     * Queries wf_status grouped by current_status for the given batchId,
+     * tallies pending (any non-terminal status) and withdrawn counts,
+     * then writes both fields into the hash in a single HMSET.
+     */
+    private void initBatchStatsFromDb(String batchId, Jedis jedis, String key) {
+        logger.debug("Cache miss for batchId={}, initialising batch stats from DB", batchId);
+        var rows = wfStatusRepo.countGroupedByStatusForApplicationId(batchId);
+        long pending = 0L;
+        long withdrawn = 0L;
+        for (var row : rows) {
+            var status = (String) row[0];
+            var count = ((Number) row[1]).longValue();
+            if (!Constants.BATCH_STATS_TERMINAL_STATUSES.contains(status)) {
+                pending += count;
+            }
+            if (Constants.BATCH_STATS_FIELD_WITHDRAWN.equalsIgnoreCase(status)) {
+                withdrawn = count;
             }
         }
+        jedis.hmset(key, Map.of(Constants.BATCH_STATS_FIELD_PENDING, String.valueOf(pending),
+                Constants.BATCH_STATS_FIELD_WITHDRAWN, String.valueOf(withdrawn)));
+        logger.info("Batch stats cache initialised for batchId={} pending={} withdrawn={}", batchId, pending, withdrawn);
+    }
+
+    /**
+     * Increments the given field in the batch stats hash by 1.
+     * If the key does not exist, initialises it from the DB first (lazy init).
+     */
+    public void incrementBatchFieldCount(String batchId, String field) {
+        var key = Constants.BP_BATCH_STATS_PREFIX + batchId;
+        try (Jedis jedis = jedisPool.getResource()) {
+            if (!jedis.exists(key)) {
+                initBatchStatsFromDb(batchId, jedis, key);
+            }
+            var updated = jedis.hincrBy(key, field, 1L);
+            logger.debug("Incremented field={} for batchId={} newValue={}", field, batchId, updated);
+        } catch (Exception e) {
+            logger.error("Failed to increment {} count in cache for batchId={}", field, batchId, e);
+        }
+    }
+
+    /**
+     * Decrements the given field in the batch stats hash by 1.
+     * No-op if the key does not exist — avoids creating a stale entry on decrement.
+     */
+    public void decrementBatchFieldCount(String batchId, String field) {
+        var key = Constants.BP_BATCH_STATS_PREFIX + batchId;
+        try (Jedis jedis = jedisPool.getResource()) {
+            if (!jedis.exists(key)) {
+                logger.debug("Skipping decrement for field={} batchId={} — key not in cache", field, batchId);
+                return;
+            }
+            var updated = jedis.hincrBy(key, field, -1L);
+            logger.debug("Decremented field={} for batchId={} newValue={}", field, batchId, updated);
+        } catch (Exception e) {
+            logger.error("Failed to decrement {} count in cache for batchId={}", field, batchId, e);
+        }
+    }
+
+    /**
+     * Returns all stats fields for the given batch from the Redis hash.
+     * Initialises from the DB on cache miss.
+     */
+    public Map<String, String> getBatchStats(String batchId) {
+        var key = Constants.BP_BATCH_STATS_PREFIX + batchId;
+        try (Jedis jedis = jedisPool.getResource()) {
+            if (!jedis.exists(key)) {
+                initBatchStatsFromDb(batchId, jedis, key);
+            }
+            return jedis.hgetAll(key);
+        } catch (Exception e) {
+            logger.error("Failed to read batch stats from cache for batchId={}", batchId, e);
+            return Collections.emptyMap();
+        }
+    }
 }

--- a/src/main/java/org/sunbird/workflow/config/WorkflowRedisCacheMgr.java
+++ b/src/main/java/org/sunbird/workflow/config/WorkflowRedisCacheMgr.java
@@ -15,12 +15,15 @@ public class WorkflowRedisCacheMgr {
 
     private final JedisPool jedisPool;
     private final WfStatusRepo wfStatusRepo;
+    private final Configuration configuration;
     private final Logger logger = LoggerFactory.getLogger(WorkflowRedisCacheMgr.class);
 
     public WorkflowRedisCacheMgr(@Qualifier("jedisWorkflowPopulationPool") JedisPool jedisPool,
-                                 WfStatusRepo wfStatusRepo) {
+                                 WfStatusRepo wfStatusRepo,
+                                 Configuration configuration) {
         this.jedisPool = jedisPool;
         this.wfStatusRepo = wfStatusRepo;
+        this.configuration = configuration;
     }
 
     public void put(String key, String value, int ttl, int index) {
@@ -67,7 +70,9 @@ public class WorkflowRedisCacheMgr {
         }
         jedis.hmset(key, Map.of(Constants.BATCH_STATS_FIELD_PENDING, String.valueOf(pending),
                 Constants.BATCH_STATS_FIELD_WITHDRAWN, String.valueOf(withdrawn)));
-        logger.info("Batch stats cache initialised for batchId={} pending={} withdrawn={}", batchId, pending, withdrawn);
+        jedis.expire(key, configuration.getBpBatchStatsCacheTtl());
+        logger.info("Batch stats cache initialised for batchId={} pending={} withdrawn={} ttl={}s",
+                batchId, pending, withdrawn, configuration.getBpBatchStatsCacheTtl());
     }
 
     /**
@@ -77,6 +82,7 @@ public class WorkflowRedisCacheMgr {
     public void incrementBatchFieldCount(String batchId, String field) {
         var key = Constants.BP_BATCH_STATS_PREFIX + batchId;
         try (Jedis jedis = jedisPool.getResource()) {
+            jedis.select(configuration.getBpBatchStatsCacheIndex());
             if (!jedis.exists(key)) {
                 initBatchStatsFromDb(batchId, jedis, key);
             }
@@ -94,6 +100,7 @@ public class WorkflowRedisCacheMgr {
     public void decrementBatchFieldCount(String batchId, String field) {
         var key = Constants.BP_BATCH_STATS_PREFIX + batchId;
         try (Jedis jedis = jedisPool.getResource()) {
+            jedis.select(configuration.getBpBatchStatsCacheIndex());
             if (!jedis.exists(key)) {
                 logger.debug("Skipping decrement for field={} batchId={} — key not in cache", field, batchId);
                 return;
@@ -112,6 +119,7 @@ public class WorkflowRedisCacheMgr {
     public Map<String, String> getBatchStats(String batchId) {
         var key = Constants.BP_BATCH_STATS_PREFIX + batchId;
         try (Jedis jedis = jedisPool.getResource()) {
+            jedis.select(configuration.getBpBatchStatsCacheIndex());
             if (!jedis.exists(key)) {
                 initBatchStatsFromDb(batchId, jedis, key);
             }

--- a/src/main/java/org/sunbird/workflow/config/WorkflowRedisCacheMgr.java
+++ b/src/main/java/org/sunbird/workflow/config/WorkflowRedisCacheMgr.java
@@ -58,21 +58,27 @@ public class WorkflowRedisCacheMgr {
         var rows = wfStatusRepo.countGroupedByStatusForApplicationId(batchId);
         long pending = 0L;
         long withdrawn = 0L;
+        long rejected = 0L;
         for (var row : rows) {
             var status = (String) row[0];
             var count = ((Number) row[1]).longValue();
             if (!Constants.BATCH_STATS_TERMINAL_STATUSES.contains(status)) {
                 pending += count;
             }
-            if (Constants.BATCH_STATS_FIELD_WITHDRAWN.equalsIgnoreCase(status)) {
+            if (Constants.WITHDRAWN.equalsIgnoreCase(status)) {
                 withdrawn = count;
             }
+            if (Constants.REJECTED.equalsIgnoreCase(status)) {
+                rejected = count;
+            }
         }
-        jedis.hmset(key, Map.of(Constants.BATCH_STATS_FIELD_PENDING, String.valueOf(pending),
-                Constants.BATCH_STATS_FIELD_WITHDRAWN, String.valueOf(withdrawn)));
+        jedis.hmset(key, Map.of(
+                Constants.BATCH_STATS_FIELD_PENDING, String.valueOf(pending),
+                Constants.BATCH_STATS_FIELD_WITHDRAWN, String.valueOf(withdrawn),
+                Constants.BATCH_STATS_FIELD_REJECTED, String.valueOf(rejected)));
         jedis.expire(key, configuration.getBpBatchStatsCacheTtl());
-        logger.info("Batch stats cache initialised for batchId={} pending={} withdrawn={} ttl={}s",
-                batchId, pending, withdrawn, configuration.getBpBatchStatsCacheTtl());
+        logger.info("Batch stats cache initialised for batchId={} pending={} withdrawn={} rejected={} ttl={}s",
+                batchId, pending, withdrawn, rejected, configuration.getBpBatchStatsCacheTtl());
     }
 
     /**

--- a/src/main/java/org/sunbird/workflow/consumer/BatchStatsConsumer.java
+++ b/src/main/java/org/sunbird/workflow/consumer/BatchStatsConsumer.java
@@ -1,0 +1,58 @@
+package org.sunbird.workflow.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+import org.sunbird.workflow.config.WorkflowRedisCacheMgr;
+import org.sunbird.workflow.models.BatchStatsEvent;
+
+/**
+ * Kafka consumer for blended program batch enrollment stats.
+ * Listens on the bp.batch.enrollment.stats topic and applies
+ * Redis HINCRBY operations asynchronously, decoupling Redis writes
+ * from the enrollment/withdrawal request path.
+ */
+@Service
+public class BatchStatsConsumer {
+
+    private static final Logger logger = LogManager.getLogger(BatchStatsConsumer.class);
+
+    private final ObjectMapper mapper;
+    private final WorkflowRedisCacheMgr workflowRedisCacheMgr;
+
+    public BatchStatsConsumer(ObjectMapper mapper, WorkflowRedisCacheMgr workflowRedisCacheMgr) {
+        this.mapper = mapper;
+        this.workflowRedisCacheMgr = workflowRedisCacheMgr;
+    }
+
+    /**
+     * Deserialises the incoming {@link BatchStatsEvent} and routes to the
+     * appropriate cache operation based on the delta sign:
+     * positive delta → increment, negative delta → decrement.
+     */
+    @KafkaListener(topics = "${kafka.topics.bp.batch.stats}", groupId = "bp-batch-stats-consumer")
+    public void processMessage(ConsumerRecord<String, String> data) {
+        try {
+            if (data.value() == null || data.value().isBlank()) {
+                logger.warn("Empty message received in BatchStatsConsumer at offset={} partition={}",
+                        data.offset(), data.partition());
+                return;
+            }
+            var event = mapper.readValue(data.value(), BatchStatsEvent.class);
+            logger.debug("Processing BatchStatsEvent batchId={} field={} delta={}",
+                    event.getBatchId(), event.getField(), event.getDelta());
+            if (event.getDelta() > 0) {
+                workflowRedisCacheMgr.incrementBatchFieldCount(event.getBatchId(), event.getField());
+            } else if (event.getDelta() < 0) {
+                workflowRedisCacheMgr.decrementBatchFieldCount(event.getBatchId(), event.getField());
+            } else {
+                logger.warn("Received BatchStatsEvent with delta=0 for batchId={}, ignoring", event.getBatchId());
+            }
+        } catch (Exception e) {
+            logger.error("Error processing BatchStatsEvent payload={} error={}", data.value(), e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/org/sunbird/workflow/models/BatchStatsEvent.java
+++ b/src/main/java/org/sunbird/workflow/models/BatchStatsEvent.java
@@ -1,0 +1,19 @@
+package org.sunbird.workflow.models;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Kafka event payload for asynchronous batch enrollment stat updates.
+ * delta > 0 → increment the field; delta < 0 → decrement the field.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class BatchStatsEvent {
+
+    private String batchId;
+    private String field;
+    private long delta;
+}

--- a/src/main/java/org/sunbird/workflow/postgres/repo/WfStatusRepo.java
+++ b/src/main/java/org/sunbird/workflow/postgres/repo/WfStatusRepo.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import org.springframework.transaction.annotation.Transactional;
 import org.sunbird.workflow.postgres.entity.WfStatusEntity;
@@ -75,6 +76,13 @@ public interface WfStatusRepo extends JpaRepository<WfStatusEntity, String> {
     @Query(value = "SELECT current_status AS currentStatus, COUNT(*) AS statusCount FROM wingspan.wf_status WHERE application_id IN ?1 GROUP BY current_status" , nativeQuery = true )
     List<Object[]> findStatusCountByApplicationId(List<String> applicationIds);
 
+    /**
+     * Returns the count of wf_status records grouped by current_status for the given batchId (applicationId).
+     * Each row is [current_status (String), count (Long)].
+     * Used to lazily initialise the Redis batch stats cache without multiple round-trips.
+     */
+    @Query(value = "SELECT current_status, COUNT(*) FROM wingspan.wf_status WHERE application_id = :applicationId GROUP BY current_status", nativeQuery = true)
+    List<Object[]> countGroupedByStatusForApplicationId(@Param("applicationId") String applicationId);
 
     @Query(value = "SELECT * FROM wingspan.wf_status WHERE " +
             "current_status IN (?1) AND " +

--- a/src/main/java/org/sunbird/workflow/service/impl/BPWorkFlowServiceImpl.java
+++ b/src/main/java/org/sunbird/workflow/service/impl/BPWorkFlowServiceImpl.java
@@ -24,6 +24,7 @@ import org.springframework.util.ObjectUtils;
 import org.springframework.web.multipart.MultipartFile;
 import org.sunbird.workflow.config.Configuration;
 import org.sunbird.workflow.config.Constants;
+import org.sunbird.workflow.models.BatchStatsEvent;
 import org.sunbird.workflow.exception.ApplicationException;
 import org.sunbird.workflow.exception.BadRequestException;
 import org.sunbird.workflow.exception.InvalidDataInputException;
@@ -140,7 +141,12 @@ public class BPWorkFlowServiceImpl implements BPWorkFlowService {
             response.put(Constants.STATUS, HttpStatus.BAD_REQUEST);
             return response;
         }
-        return workflowService.workflowTransition(rootOrg, org, wfRequest, userId,role);
+        Response wfResponse = workflowService.workflowTransition(rootOrg, org, wfRequest, userId, role);
+        Map<String, Object> responseData = (Map<String, Object>) wfResponse.get(Constants.DATA);
+        if (responseData != null) {
+            publishBatchStatsOnStatusChange(wfRequest.getApplicationId(), (String) responseData.get(Constants.STATUS));
+        }
+        return wfResponse;
     }
 
     @Override
@@ -596,7 +602,8 @@ public class BPWorkFlowServiceImpl implements BPWorkFlowService {
         applicationStatus.setComment(wfRequest.getComment());
         wfRequest.setWfId(wfId);
         wfStatusRepo.save(applicationStatus);
-
+        logger.info("Admin enrolment wf_status saved, publishing pending increment for batchId={} userId={}", wfRequest.getApplicationId(), wfRequest.getUserId());
+        producer.push(configuration.getBpBatchStatsTopic(), new BatchStatsEvent(wfRequest.getApplicationId(), Constants.BATCH_STATS_FIELD_PENDING, 1L));
         Response response = new Response();
         HashMap<String, Object> data = new HashMap<>();
         data.put(Constants.STATUS, Constants.ADMIN_ENROLL_IS_IN_PROGRESS);
@@ -958,6 +965,8 @@ public class BPWorkFlowServiceImpl implements BPWorkFlowService {
         applicationStatus.setComment(wfRequest.getComment());
         wfRequest.setWfId(wfId);
         wfStatusRepo.save(applicationStatus);
+        logger.info("Self enrolment wf_status saved, publishing pending increment for batchId={} userId={}", wfRequest.getApplicationId(), wfRequest.getUserId());
+        producer.push(configuration.getBpBatchStatsTopic(), new BatchStatsEvent(wfRequest.getApplicationId(), Constants.BATCH_STATS_FIELD_PENDING, 1L));
         Response response = new Response();
         HashMap<String, Object> data = new HashMap<>();
         data.put(Constants.STATUS, Constants.ENROLL_IS_IN_PROGRESS);
@@ -1648,6 +1657,7 @@ public class BPWorkFlowServiceImpl implements BPWorkFlowService {
                             req.setComment("Superseded by " + incomingRole + " nomination");
                             req.setLastUpdatedOn(new Date());
                             wfStatusRepo.save(req);
+                            publishBatchStatsOnStatusChange(req.getApplicationId(), Constants.WITHDRAWN);
                         } else {
                             logger.info("Skipping nomination - existing approval by {} remains active", existingRole);
                             userResponse.put(Constants.STATUS, Constants.ALREADY_EXISTS);
@@ -1915,6 +1925,19 @@ public class BPWorkFlowServiceImpl implements BPWorkFlowService {
         applicationStatus.setLastUpdatedOn(new Date());
         applicationStatus.setCurrentStatus(Constants.SEND_FOR_PC_APPROVAL);
         WfStatusEntity savedEntity = wfStatusRepo.save(applicationStatus);
+    }
+
+    /**
+     * Publishes batch enrollment stat events to Kafka based on the workflow status transition.
+     * The consumer updates Redis asynchronously, keeping the enrollment path non-blocking.
+     * Add new else-if blocks here when additional status transitions need to be tracked.
+     */
+    private void publishBatchStatsOnStatusChange(String batchId, String status) {
+        if (Constants.WITHDRAWN.equals(status)) {
+            logger.info("Publishing batch stats withdrawal events for batchId={}", batchId);
+            producer.push(configuration.getBpBatchStatsTopic(), new BatchStatsEvent(batchId, Constants.BATCH_STATS_FIELD_PENDING, -1L));
+            producer.push(configuration.getBpBatchStatsTopic(), new BatchStatsEvent(batchId, Constants.BATCH_STATS_FIELD_WITHDRAWN, 1L));
+        }
     }
 
 }

--- a/src/main/java/org/sunbird/workflow/service/impl/BPWorkFlowServiceImpl.java
+++ b/src/main/java/org/sunbird/workflow/service/impl/BPWorkFlowServiceImpl.java
@@ -1939,6 +1939,12 @@ public class BPWorkFlowServiceImpl implements BPWorkFlowService {
             logger.info("Publishing batch stats withdrawal events for batchId={}", batchId);
             producer.push(configuration.getBpBatchStatsTopic(), new BatchStatsEvent(batchId, Constants.BATCH_STATS_FIELD_PENDING, -1L));
             producer.push(configuration.getBpBatchStatsTopic(), new BatchStatsEvent(batchId, Constants.BATCH_STATS_FIELD_WITHDRAWN, 1L));
+        } else if (Constants.APPROVED_STATE.equals(status)) {
+            logger.info("Publishing batch stats approval events for batchId={}", batchId);
+            producer.push(configuration.getBpBatchStatsTopic(), new BatchStatsEvent(batchId, Constants.BATCH_STATS_FIELD_PENDING, -1L));
+        } else if (Constants.REJECTED.equals(status)) {
+            logger.info("Publishing batch stats rejection events for batchId={}", batchId);
+            producer.push(configuration.getBpBatchStatsTopic(), new BatchStatsEvent(batchId, Constants.BATCH_STATS_FIELD_PENDING, -1L));
         }
     }
 

--- a/src/main/java/org/sunbird/workflow/service/impl/BPWorkFlowServiceImpl.java
+++ b/src/main/java/org/sunbird/workflow/service/impl/BPWorkFlowServiceImpl.java
@@ -1945,6 +1945,7 @@ public class BPWorkFlowServiceImpl implements BPWorkFlowService {
         } else if (Constants.REJECTED.equals(status)) {
             logger.info("Publishing batch stats rejection events for batchId={}", batchId);
             producer.push(configuration.getBpBatchStatsTopic(), new BatchStatsEvent(batchId, Constants.BATCH_STATS_FIELD_PENDING, -1L));
+            producer.push(configuration.getBpBatchStatsTopic(), new BatchStatsEvent(batchId, Constants.BATCH_STATS_FIELD_REJECTED, 1L));
         }
     }
 

--- a/src/main/java/org/sunbird/workflow/service/impl/BPWorkFlowServiceImpl.java
+++ b/src/main/java/org/sunbird/workflow/service/impl/BPWorkFlowServiceImpl.java
@@ -142,9 +142,11 @@ public class BPWorkFlowServiceImpl implements BPWorkFlowService {
             return response;
         }
         Response wfResponse = workflowService.workflowTransition(rootOrg, org, wfRequest, userId, role);
-        Map<String, Object> responseData = (Map<String, Object>) wfResponse.get(Constants.DATA);
-        if (responseData != null) {
-            publishBatchStatsOnStatusChange(wfRequest.getApplicationId(), (String) responseData.get(Constants.STATUS));
+        if (wfResponse != null) {
+            Map<String, Object> responseData = (Map<String, Object>) wfResponse.get(Constants.DATA);
+            if (responseData != null) {
+                publishBatchStatsOnStatusChange(wfRequest.getApplicationId(), (String) responseData.get(Constants.STATUS));
+            }
         }
         return wfResponse;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -181,3 +181,6 @@ ai.assessment.initiate.roles=CONTENT_CREATOR,CONTENT_REVIEWER,CONTENT_PUBLISHER,
 ai.assessment.approve.reject.roles=SPV PUBLISHER
 accesstoken.publickey.basepath=publickey
 sunbird_time_zone=Asia/Kolkata
+
+bp.batch.stats.cache.ttl=14400
+bp.batch.stats.cache.index=2

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -62,6 +62,7 @@ kafka.topics.workflow.notification=workflowNotificationTopic
 kafka.topics.user.registration.createUser=workflow.user.registration.createUser
 kafka.topics.workflow.request.v2=workflowContentTopicV2
 kafka.topics.workflow.notification.v2=workflowNotificationTopicV2
+kafka.topics.bp.batch.stats=bp.batch.enrollment.stats
 
 #Kafka Server
 spring.kafka.bootstrap.servers=localhost:9092

--- a/src/test/java/org/sunbird/workflow/config/WorkflowRedisCacheMgrTest.java
+++ b/src/test/java/org/sunbird/workflow/config/WorkflowRedisCacheMgrTest.java
@@ -1,0 +1,217 @@
+package org.sunbird.workflow.config;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.sunbird.workflow.postgres.repo.WfStatusRepo;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPool;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class WorkflowRedisCacheMgrTest {
+
+    @Mock
+    private JedisPool jedisPool;
+
+    @Mock
+    private WfStatusRepo wfStatusRepo;
+
+    @Mock
+    private Jedis jedis;
+
+    private WorkflowRedisCacheMgr cacheMgr;
+
+    @Captor
+    private ArgumentCaptor<Map<String, String>> mapCaptor;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        cacheMgr = new WorkflowRedisCacheMgr(jedisPool, wfStatusRepo);
+        when(jedisPool.getResource()).thenReturn(jedis);
+    }
+
+
+    @Test
+    void put_setsKeyValueAndExpiry() {
+        cacheMgr.put("myKey", "myValue", 300, 2);
+        verify(jedis).select(2);
+        verify(jedis).set("myKey", "myValue");
+        verify(jedis).expire("myKey", 300);
+    }
+
+    @Test
+    void put_doesNotThrowWhenRedisUnavailable() {
+        when(jedisPool.getResource()).thenThrow(new RuntimeException("Connection refused"));
+        assertDoesNotThrow(() -> cacheMgr.put("k", "v", 60, 0));
+    }
+
+    @Test
+    void get_returnsValueFromRedis() {
+        when(jedis.get("myKey")).thenReturn("cached");
+        String result = cacheMgr.get("myKey", 1);
+        assertEquals("cached", result);
+        verify(jedis).select(1);
+    }
+
+    @Test
+    void get_returnsNullWhenRedisUnavailable() {
+        when(jedisPool.getResource()).thenThrow(new RuntimeException("Connection refused"));
+        assertNull(cacheMgr.get("myKey", 0));
+    }
+
+    @Test
+    void increment_whenKeyExists_hincrByWithoutInitialisingFromDb() {
+        String batchId = "batch-001";
+        String key = Constants.BP_BATCH_STATS_PREFIX + batchId;
+        when(jedis.exists(key)).thenReturn(true);
+        cacheMgr.incrementBatchFieldCount(batchId, Constants.BATCH_STATS_FIELD_PENDING);
+        verify(wfStatusRepo, never()).countGroupedByStatusForApplicationId(any());
+        verify(jedis).hincrBy(key, Constants.BATCH_STATS_FIELD_PENDING, 1L);
+    }
+
+
+    @Test
+    void increment_whenKeyMissing_initFromDbThenIncrBy() {
+        String batchId = "batch-002";
+        String key = Constants.BP_BATCH_STATS_PREFIX + batchId;
+        when(jedis.exists(key)).thenReturn(false);
+        // ENROLL_IS_IN_PROGRESS is non-terminal → counts as pending
+        // APPROVED is terminal → skipped for pending
+        // WITHDRAWN is terminal → counted as withdrawn
+        List<Object[]> dbRows = new ArrayList<>();
+        dbRows.add(new Object[]{"ENROLL_IS_IN_PROGRESS", 3L});
+        dbRows.add(new Object[]{"APPROVED", 2L});
+        dbRows.add(new Object[]{"WITHDRAWN", 1L});
+        when(wfStatusRepo.countGroupedByStatusForApplicationId(batchId)).thenReturn(dbRows);
+        cacheMgr.incrementBatchFieldCount(batchId, Constants.BATCH_STATS_FIELD_PENDING);
+        // pending = 3, withdrawn = 1
+        verify(jedis).hmset(key, Map.of(
+                Constants.BATCH_STATS_FIELD_PENDING, "3",
+                Constants.BATCH_STATS_FIELD_WITHDRAWN, "1"
+        ));
+        verify(jedis).hincrBy(key, Constants.BATCH_STATS_FIELD_PENDING, 1L);
+    }
+
+    @Test
+    void increment_whenDbReturnsOnlyTerminalStatuses_pendingAndWithdrawnAreZero() {
+        String batchId = "batch-003";
+        String key = Constants.BP_BATCH_STATS_PREFIX + batchId;
+        when(jedis.exists(key)).thenReturn(false);
+        List<Object[]> dbRows = new ArrayList<>();
+        dbRows.add(new Object[]{"APPROVED", 10L});
+        dbRows.add(new Object[]{"REJECTED", 5L});
+        dbRows.add(new Object[]{"REMOVED", 2L});
+        when(wfStatusRepo.countGroupedByStatusForApplicationId(batchId)).thenReturn(dbRows);
+        cacheMgr.incrementBatchFieldCount(batchId, Constants.BATCH_STATS_FIELD_PENDING);
+        verify(jedis).hmset(key, Map.of(
+                Constants.BATCH_STATS_FIELD_PENDING, "0",
+                Constants.BATCH_STATS_FIELD_WITHDRAWN, "0"
+        ));
+    }
+
+    @Test
+    void increment_whenDbReturnsEmptyRows_zeroCounts() {
+        String batchId = "batch-004";
+        String key = Constants.BP_BATCH_STATS_PREFIX + batchId;
+        when(jedis.exists(key)).thenReturn(false);
+        when(wfStatusRepo.countGroupedByStatusForApplicationId(batchId)).thenReturn(Collections.emptyList());
+        cacheMgr.incrementBatchFieldCount(batchId, Constants.BATCH_STATS_FIELD_PENDING);
+        verify(jedis).hmset(key, Map.of(
+                Constants.BATCH_STATS_FIELD_PENDING, "0",
+                Constants.BATCH_STATS_FIELD_WITHDRAWN, "0"
+        ));
+    }
+
+    @Test
+    void increment_doesNotThrowWhenRedisUnavailable() {
+        when(jedisPool.getResource()).thenThrow(new RuntimeException("Redis down"));
+        assertDoesNotThrow(() -> cacheMgr.incrementBatchFieldCount("b1", Constants.BATCH_STATS_FIELD_PENDING));
+    }
+
+    @Test
+    void decrement_whenKeyExists_hincrByNegativeOne() {
+        String batchId = "batch-005";
+        String key = Constants.BP_BATCH_STATS_PREFIX + batchId;
+        when(jedis.exists(key)).thenReturn(true);
+        cacheMgr.decrementBatchFieldCount(batchId, Constants.BATCH_STATS_FIELD_PENDING);
+        verify(jedis).hincrBy(key, Constants.BATCH_STATS_FIELD_PENDING, -1L);
+    }
+
+    @Test
+    void decrement_whenKeyMissing_isNoOpAndDoesNotInitFromDb() {
+        String batchId = "batch-006";
+        String key = Constants.BP_BATCH_STATS_PREFIX + batchId;
+        when(jedis.exists(key)).thenReturn(false);
+        cacheMgr.decrementBatchFieldCount(batchId, Constants.BATCH_STATS_FIELD_PENDING);
+        verify(jedis, never()).hincrBy(any(String.class), any(String.class), anyLong());
+        verify(wfStatusRepo, never()).countGroupedByStatusForApplicationId(any());
+    }
+
+    @Test
+    void decrement_doesNotThrowWhenRedisUnavailable() {
+        when(jedisPool.getResource()).thenThrow(new RuntimeException("Redis down"));
+        assertDoesNotThrow(() -> cacheMgr.decrementBatchFieldCount("b1", Constants.BATCH_STATS_FIELD_PENDING));
+    }
+
+    @Test
+    void getBatchStats_whenKeyExists_returnsHgetAllWithoutDbInit() {
+        String batchId = "batch-007";
+        String key = Constants.BP_BATCH_STATS_PREFIX + batchId;
+        when(jedis.exists(key)).thenReturn(true);
+        Map<String, String> expected = Map.of("pending", "7", "withdrawn", "2");
+        when(jedis.hgetAll(key)).thenReturn(expected);
+        Map<String, String> result = cacheMgr.getBatchStats(batchId);
+        assertEquals(expected, result);
+        verify(wfStatusRepo, never()).countGroupedByStatusForApplicationId(any());
+    }
+
+    @Test
+    void getBatchStats_whenKeyMissing_initFromDbThenReturnHgetAll() {
+        String batchId = "batch-008";
+        String key = Constants.BP_BATCH_STATS_PREFIX + batchId;
+        when(jedis.exists(key)).thenReturn(false);
+        List<Object[]> dbRows = new ArrayList<>();
+        dbRows.add(new Object[]{"ENROLL_IS_IN_PROGRESS", 5L});
+        when(wfStatusRepo.countGroupedByStatusForApplicationId(batchId)).thenReturn(dbRows);
+        Map<String, String> expected = Map.of("pending", "5", "withdrawn", "0");
+        when(jedis.hgetAll(key)).thenReturn(expected);
+        Map<String, String> result = cacheMgr.getBatchStats(batchId);
+        verify(jedis).hmset(eq(key), argThat(m ->
+                "5".equals(m.get(Constants.BATCH_STATS_FIELD_PENDING)) &&
+                "0".equals(m.get(Constants.BATCH_STATS_FIELD_WITHDRAWN))
+        ));
+        assertEquals(expected, result);
+    }
+
+    @Test
+    void getBatchStats_whenRedisUnavailable_returnsEmptyMap() {
+        when(jedisPool.getResource()).thenThrow(new RuntimeException("Redis down"));
+        Map<String, String> result = cacheMgr.getBatchStats("batch-009");
+        assertEquals(Collections.emptyMap(), result);
+    }
+
+
+    @Test
+    void increment_withdrawnStatusInDb_isCountedAsWithdrawnNotPending() {
+        String batchId = "batch-010";
+        String key = Constants.BP_BATCH_STATS_PREFIX + batchId;
+        when(jedis.exists(key)).thenReturn(false);
+        List<Object[]> dbRows = new ArrayList<>();
+        dbRows.add(new Object[]{"WITHDRAWN", 3L});
+        when(wfStatusRepo.countGroupedByStatusForApplicationId(batchId)).thenReturn(dbRows);
+        cacheMgr.incrementBatchFieldCount(batchId, Constants.BATCH_STATS_FIELD_WITHDRAWN);
+        verify(jedis).hmset(eq(key), mapCaptor.capture());
+        Map<String, String> stored = mapCaptor.getValue();
+        assertEquals("3", stored.get(Constants.BATCH_STATS_FIELD_WITHDRAWN));
+        assertEquals("0", stored.get(Constants.BATCH_STATS_FIELD_PENDING));
+    }
+}

--- a/src/test/java/org/sunbird/workflow/config/WorkflowRedisCacheMgrTest.java
+++ b/src/test/java/org/sunbird/workflow/config/WorkflowRedisCacheMgrTest.java
@@ -101,7 +101,8 @@ class WorkflowRedisCacheMgrTest {
         // pending = 3, withdrawn = 1
         verify(jedis).hmset(key, Map.of(
                 Constants.BATCH_STATS_FIELD_PENDING, "3",
-                Constants.BATCH_STATS_FIELD_WITHDRAWN, "1"
+                Constants.BATCH_STATS_FIELD_WITHDRAWN, "1",
+                Constants.BATCH_STATS_FIELD_REJECTED, "0"
         ));
         verify(jedis).hincrBy(key, Constants.BATCH_STATS_FIELD_PENDING, 1L);
     }
@@ -119,7 +120,8 @@ class WorkflowRedisCacheMgrTest {
         cacheMgr.incrementBatchFieldCount(batchId, Constants.BATCH_STATS_FIELD_PENDING);
         verify(jedis).hmset(key, Map.of(
                 Constants.BATCH_STATS_FIELD_PENDING, "0",
-                Constants.BATCH_STATS_FIELD_WITHDRAWN, "0"
+                Constants.BATCH_STATS_FIELD_WITHDRAWN, "0",
+                Constants.BATCH_STATS_FIELD_REJECTED, "0"
         ));
     }
 
@@ -132,7 +134,8 @@ class WorkflowRedisCacheMgrTest {
         cacheMgr.incrementBatchFieldCount(batchId, Constants.BATCH_STATS_FIELD_PENDING);
         verify(jedis).hmset(key, Map.of(
                 Constants.BATCH_STATS_FIELD_PENDING, "0",
-                Constants.BATCH_STATS_FIELD_WITHDRAWN, "0"
+                Constants.BATCH_STATS_FIELD_WITHDRAWN, "0",
+                Constants.BATCH_STATS_FIELD_REJECTED, "0"
         ));
     }
 
@@ -192,7 +195,8 @@ class WorkflowRedisCacheMgrTest {
         Map<String, String> result = cacheMgr.getBatchStats(batchId);
         verify(jedis).hmset(eq(key), argThat(m ->
                 "5".equals(m.get(Constants.BATCH_STATS_FIELD_PENDING)) &&
-                "0".equals(m.get(Constants.BATCH_STATS_FIELD_WITHDRAWN))
+                "0".equals(m.get(Constants.BATCH_STATS_FIELD_WITHDRAWN)) &&
+                "0".equals(m.get(Constants.BATCH_STATS_FIELD_REJECTED))
         ));
         assertEquals(expected, result);
     }
@@ -218,5 +222,23 @@ class WorkflowRedisCacheMgrTest {
         Map<String, String> stored = mapCaptor.getValue();
         assertEquals("3", stored.get(Constants.BATCH_STATS_FIELD_WITHDRAWN));
         assertEquals("0", stored.get(Constants.BATCH_STATS_FIELD_PENDING));
+        assertEquals("0", stored.get(Constants.BATCH_STATS_FIELD_REJECTED));
+    }
+
+    @Test
+    void increment_rejectedStatusInDb_isCountedAsRejectedNotPending() {
+        String batchId = "batch-011";
+        String key = Constants.BP_BATCH_STATS_PREFIX + batchId;
+        when(jedis.exists(key)).thenReturn(false);
+        List<Object[]> dbRows = new ArrayList<>();
+        dbRows.add(new Object[]{"REJECTED", 4L});
+        dbRows.add(new Object[]{"ENROLL_IS_IN_PROGRESS", 2L});
+        when(wfStatusRepo.countGroupedByStatusForApplicationId(batchId)).thenReturn(dbRows);
+        cacheMgr.incrementBatchFieldCount(batchId, Constants.BATCH_STATS_FIELD_PENDING);
+        verify(jedis).hmset(eq(key), mapCaptor.capture());
+        Map<String, String> stored = mapCaptor.getValue();
+        assertEquals("4", stored.get(Constants.BATCH_STATS_FIELD_REJECTED));
+        assertEquals("2", stored.get(Constants.BATCH_STATS_FIELD_PENDING));
+        assertEquals("0", stored.get(Constants.BATCH_STATS_FIELD_WITHDRAWN));
     }
 }

--- a/src/test/java/org/sunbird/workflow/config/WorkflowRedisCacheMgrTest.java
+++ b/src/test/java/org/sunbird/workflow/config/WorkflowRedisCacheMgrTest.java
@@ -25,6 +25,9 @@ class WorkflowRedisCacheMgrTest {
     private WfStatusRepo wfStatusRepo;
 
     @Mock
+    private Configuration configuration;
+
+    @Mock
     private Jedis jedis;
 
     private WorkflowRedisCacheMgr cacheMgr;
@@ -35,8 +38,10 @@ class WorkflowRedisCacheMgrTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        cacheMgr = new WorkflowRedisCacheMgr(jedisPool, wfStatusRepo);
+        cacheMgr = new WorkflowRedisCacheMgr(jedisPool, wfStatusRepo, configuration);
         when(jedisPool.getResource()).thenReturn(jedis);
+        when(configuration.getBpBatchStatsCacheTtl()).thenReturn(14400);
+        when(configuration.getBpBatchStatsCacheIndex()).thenReturn(2);
     }
 
 

--- a/src/test/java/org/sunbird/workflow/config/WorkflowRedisCacheMgrTest.java
+++ b/src/test/java/org/sunbird/workflow/config/WorkflowRedisCacheMgrTest.java
@@ -121,7 +121,7 @@ class WorkflowRedisCacheMgrTest {
         verify(jedis).hmset(key, Map.of(
                 Constants.BATCH_STATS_FIELD_PENDING, "0",
                 Constants.BATCH_STATS_FIELD_WITHDRAWN, "0",
-                Constants.BATCH_STATS_FIELD_REJECTED, "0"
+                Constants.BATCH_STATS_FIELD_REJECTED, "5"
         ));
     }
 

--- a/src/test/java/org/sunbird/workflow/consumer/BatchStatsConsumerTest.java
+++ b/src/test/java/org/sunbird/workflow/consumer/BatchStatsConsumerTest.java
@@ -1,0 +1,107 @@
+package org.sunbird.workflow.consumer;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.sunbird.workflow.config.WorkflowRedisCacheMgr;
+import org.sunbird.workflow.models.BatchStatsEvent;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.mockito.Mockito.*;
+
+class BatchStatsConsumerTest {
+
+    private static final String BATCH_ID = "batch1";
+    private static final String BATCH_ID_X = "batchX";
+    private static final String FIELD_PENDING = "pending";
+    private static final String FIELD_WITHDRAWN = "withdrawn";
+    private static final String TOPIC = "bp.batch.enrollment.stats";
+
+    @Mock
+    private ObjectMapper mapper;
+
+    @Mock
+    private WorkflowRedisCacheMgr workflowRedisCacheMgr;
+
+    private BatchStatsConsumer consumer;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        consumer = new BatchStatsConsumer(mapper, workflowRedisCacheMgr);
+    }
+
+    private ConsumerRecord<String, String> createRecord(String value) {
+        return new ConsumerRecord<>(TOPIC, 0, 42L, null, value);
+    }
+
+    @Test
+    void processMessage_positiveDelta_callsIncrement() throws Exception {
+        String payload = "{\"batchId\":\"batch1\",\"field\":\"pending\",\"delta\":1}";
+        BatchStatsEvent event = new BatchStatsEvent(BATCH_ID, FIELD_PENDING, 1L);
+        when(mapper.readValue(payload, BatchStatsEvent.class)).thenReturn(event);
+        consumer.processMessage(createRecord(payload));
+        verify(workflowRedisCacheMgr).incrementBatchFieldCount(BATCH_ID, FIELD_PENDING);
+        verify(workflowRedisCacheMgr, never()).decrementBatchFieldCount(any(), any());
+    }
+
+    @Test
+    void processMessage_negativeDelta_callsDecrement() throws Exception {
+        String payload = "{\"batchId\":\"batch1\",\"field\":\"pending\",\"delta\":-1}";
+        BatchStatsEvent event = new BatchStatsEvent(BATCH_ID, FIELD_PENDING, -1L);
+        when(mapper.readValue(payload, BatchStatsEvent.class)).thenReturn(event);
+        consumer.processMessage(createRecord(payload));
+        verify(workflowRedisCacheMgr).decrementBatchFieldCount(BATCH_ID, FIELD_PENDING);
+        verify(workflowRedisCacheMgr, never()).incrementBatchFieldCount(any(), any());
+    }
+
+    @Test
+    void processMessage_zeroDelta_callsNeither() throws Exception {
+        String payload = "{\"batchId\":\"batch1\",\"field\":\"pending\",\"delta\":0}";
+        BatchStatsEvent event = new BatchStatsEvent(BATCH_ID, FIELD_PENDING, 0L);
+        when(mapper.readValue(payload, BatchStatsEvent.class)).thenReturn(event);
+        consumer.processMessage(createRecord(payload));
+        verifyNoInteractions(workflowRedisCacheMgr);
+    }
+
+    @Test
+    void processMessage_nullValue_doesNotThrowAndSkipsProcessing() {
+        assertDoesNotThrow(() -> consumer.processMessage(createRecord(null)));
+        verifyNoInteractions(workflowRedisCacheMgr);
+    }
+
+    @Test
+    void processMessage_blankValue_doesNotThrowAndSkipsProcessing() {
+        assertDoesNotThrow(() -> consumer.processMessage(createRecord("   ")));
+        verifyNoInteractions(workflowRedisCacheMgr);
+    }
+
+    @Test
+    void processMessage_mapperThrowsException_doesNotPropagate() throws Exception {
+        String badPayload = "{invalid}";
+        when(mapper.readValue(badPayload, BatchStatsEvent.class))
+                .thenThrow(new RuntimeException("parse error"));
+        assertDoesNotThrow(() -> consumer.processMessage(createRecord(badPayload)));
+        verifyNoInteractions(workflowRedisCacheMgr);
+    }
+
+    @Test
+    void processMessage_withdrawnFieldWithNegativeDelta_callsDecrementWithCorrectArgs() throws Exception {
+        String payload = "{\"batchId\":\"batchX\",\"field\":\"withdrawn\",\"delta\":-1}";
+        BatchStatsEvent event = new BatchStatsEvent(BATCH_ID_X, FIELD_WITHDRAWN, -1L);
+        when(mapper.readValue(payload, BatchStatsEvent.class)).thenReturn(event);
+        consumer.processMessage(createRecord(payload));
+        verify(workflowRedisCacheMgr).decrementBatchFieldCount(BATCH_ID_X, FIELD_WITHDRAWN);
+    }
+
+    @Test
+    void processMessage_withdrawnFieldWithPositiveDelta_callsIncrementWithCorrectArgs() throws Exception {
+        String payload = "{\"batchId\":\"batchX\",\"field\":\"withdrawn\",\"delta\":1}";
+        BatchStatsEvent event = new BatchStatsEvent(BATCH_ID_X, FIELD_WITHDRAWN, 1L);
+        when(mapper.readValue(payload, BatchStatsEvent.class)).thenReturn(event);
+        consumer.processMessage(createRecord(payload));
+        verify(workflowRedisCacheMgr).incrementBatchFieldCount(BATCH_ID_X, FIELD_WITHDRAWN);
+    }
+}

--- a/src/test/java/org/sunbird/workflow/models/BatchStatsEventTest.java
+++ b/src/test/java/org/sunbird/workflow/models/BatchStatsEventTest.java
@@ -1,0 +1,54 @@
+package org.sunbird.workflow.models;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class BatchStatsEventTest {
+
+    @Test
+    void allArgsConstructor_setsAllFields() {
+        BatchStatsEvent event = new BatchStatsEvent("batch1", "pending", 1L);
+
+        assertEquals("batch1", event.getBatchId());
+        assertEquals("pending", event.getField());
+        assertEquals(1L, event.getDelta());
+    }
+
+    @Test
+    void noArgsConstructor_fieldsAreDefault() {
+        BatchStatsEvent event = new BatchStatsEvent();
+        assertNull(event.getBatchId());
+        assertNull(event.getField());
+        assertEquals(0L, event.getDelta());
+    }
+
+    @Test
+    void setters_updateFields() {
+        BatchStatsEvent event = new BatchStatsEvent();
+        event.setBatchId("batch99");
+        event.setField("withdrawn");
+        event.setDelta(-1L);
+        assertEquals("batch99", event.getBatchId());
+        assertEquals("withdrawn", event.getField());
+        assertEquals(-1L, event.getDelta());
+    }
+
+    @Test
+    void negativeDelta_representsDecrement() {
+        BatchStatsEvent event = new BatchStatsEvent("b1", "pending", -1L);
+        assertEquals(-1L, event.getDelta());
+    }
+
+    @Test
+    void positiveDelta_representsIncrement() {
+        BatchStatsEvent event = new BatchStatsEvent("b1", "withdrawn", 1L);
+        assertEquals(1L, event.getDelta());
+    }
+
+    @Test
+    void zeroDelta_isIgnoredByConsumer() {
+        BatchStatsEvent event = new BatchStatsEvent("b1", "pending", 0L);
+        assertEquals(0L, event.getDelta());
+    }
+}

--- a/src/test/java/org/sunbird/workflow/service/BPWorkFlowServiceImplTest.java
+++ b/src/test/java/org/sunbird/workflow/service/BPWorkFlowServiceImplTest.java
@@ -1525,4 +1525,138 @@ class BPWorkFlowServiceImplTest {
         verify(wfStatusRepo).save(entity);
     }
 
+    private WfRequest buildSkipValidationRequest() {
+        WfRequest req = new WfRequest();
+        req.setApplicationId(BATCH_ID);
+        req.setCourseId(COURSE_ID);
+        req.setUserId(USER_ID);
+        req.setAction("SKIP_VALIDATION");
+        return req;
+    }
+
+    private void stubSkipValidationAndConflictCheck() {
+        when(configuration.getBpBatchFullValidationExcludeStates())
+                .thenReturn(Collections.singletonList("SKIP_VALIDATION"));
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), anyList()))
+                .thenReturn(Collections.emptyList());
+        doReturn(false).when(bpWorkFlowService).scheduleConflictCheck(any());
+    }
+
+    @Test
+    void testUpdateBPWorkFlow_publishesTwoBatchStatsEvents_whenTransitionResultIsWithdrawn() {
+        wfRequest = buildSkipValidationRequest();
+        stubSkipValidationAndConflictCheck();
+        when(configuration.getBpBatchStatsTopic()).thenReturn("bp-stats-topic");
+        Map<String, Object> dataMap = new HashMap<>();
+        dataMap.put(Constants.STATUS, Constants.WITHDRAWN);
+        Response wfResponse = new Response();
+        wfResponse.put(Constants.DATA, dataMap);
+        when(workflowservice.workflowTransition(any(), any(), any(), any(), any())).thenReturn(wfResponse);
+        bpWorkFlowService.updateBPWorkFlow(ROOT_ORG, ORG, wfRequest, USER_ID, "role");
+        ArgumentCaptor<BatchStatsEvent> captor = ArgumentCaptor.forClass(BatchStatsEvent.class);
+        verify(producer, times(2)).push(eq("bp-stats-topic"), captor.capture());
+        List<BatchStatsEvent> events = captor.getAllValues();
+        BatchStatsEvent pendingEvent = events.stream()
+                .filter(e -> Constants.BATCH_STATS_FIELD_PENDING.equals(e.getField()))
+                .findFirst().orElse(null);
+        assertNotNull(pendingEvent, "Expected pending decrement event");
+        assertEquals(-1L, pendingEvent.getDelta());
+        BatchStatsEvent withdrawnEvent = events.stream()
+                .filter(e -> Constants.BATCH_STATS_FIELD_WITHDRAWN.equals(e.getField()))
+                .findFirst().orElse(null);
+        assertNotNull(withdrawnEvent, "Expected withdrawn increment event");
+        assertEquals(1L, withdrawnEvent.getDelta());
+    }
+
+    @Test
+    void testUpdateBPWorkFlow_doesNotPublishBatchStats_whenTransitionResponseDataIsNull() {
+        wfRequest = buildSkipValidationRequest();
+        stubSkipValidationAndConflictCheck();
+        Response wfResponse = new Response();
+        when(workflowservice.workflowTransition(any(), any(), any(), any(), any())).thenReturn(wfResponse);
+        bpWorkFlowService.updateBPWorkFlow(ROOT_ORG, ORG, wfRequest, USER_ID, "role");
+        verify(producer, never()).push(any(), any(BatchStatsEvent.class));
+    }
+
+    @Test
+    void testUpdateBPWorkFlow_doesNotPublishBatchStats_whenTransitionStatusIsNotWithdrawn() {
+        wfRequest = buildSkipValidationRequest();
+        stubSkipValidationAndConflictCheck();
+        Map<String, Object> dataMap = new HashMap<>();
+        dataMap.put(Constants.STATUS, Constants.APPROVED_STATE);
+        Response wfResponse = new Response();
+        wfResponse.put(Constants.DATA, dataMap);
+        when(workflowservice.workflowTransition(any(), any(), any(), any(), any())).thenReturn(wfResponse);
+        bpWorkFlowService.updateBPWorkFlow(ROOT_ORG, ORG, wfRequest, USER_ID, "role");
+        verify(producer, never()).push(any(), any(BatchStatsEvent.class));
+    }
+
+    @Test
+    void testAdminEnrolBPWorkFlow_publishesPendingIncrementEvent_onSuccessfulEnrollment() throws Exception {
+        WfRequest req = getSampleRequest();
+        req.setState("SEND_FOR_PC_APPROVAL");
+        Map<String, Object> batchAttr = Map.of(
+                Constants.BATCH_ATTRIBUTES, "{\"currentBatchSize\":\"100\"}",
+                Constants.START_DATE, Instant.now(),
+                Constants.ENROLMENT_END_DATE, Instant.now().plusSeconds(3600),
+                Constants.NAME, "Test Batch"
+        );
+        when(cassandraOperation.getRecordsByProperties(
+                eq(Constants.KEYSPACE_SUNBIRD_COURSES), eq(Constants.TABLE_COURSE_BATCH), anyMap(), anyList()))
+                .thenReturn(List.of(batchAttr));
+        when(cassandraOperation.getRecordsByProperties(
+                eq(Constants.KEYSPACE_SUNBIRD_COURSES), eq(Constants.TABLE_ENROLMENT_BATCH_LOOKUP), anyMap(), anyList()))
+                .thenReturn(Collections.emptyList());
+        when(contentReadService.getServiceNameDetails(COURSE_ID))
+                .thenReturn(Map.of("wfApprovalType", "service", "primaryCategory", "Course"));
+        when(wfStatusRepo.findByApplicationId(BATCH_ID)).thenReturn(Collections.emptyList());
+        when(wfStatusRepo.findByServiceNameAndUserIdAndApplicationId(any(), any(), any()))
+                .thenReturn(Collections.emptyList());
+        when(wfStatusRepo.save(any(WfStatusEntity.class))).thenReturn(new WfStatusEntity());
+        when(configuration.getBpBatchEnrolLimitBufferSize()).thenReturn(20);
+        when(mapper.writeValueAsString(any())).thenReturn("[]");
+        when(configuration.getBpBatchStatsTopic()).thenReturn("bp-stats-topic");
+        when(configuration.getWorkflowApplicationTopic()).thenReturn("wf-topic");
+        doReturn(false).when(bpWorkFlowService).scheduleConflictCheck(any());
+        bpWorkFlowService.adminEnrolBPWorkFlow(ROOT_ORG, ORG, req);
+        ArgumentCaptor<BatchStatsEvent> captor = ArgumentCaptor.forClass(BatchStatsEvent.class);
+        verify(producer).push(eq("bp-stats-topic"), captor.capture());
+        BatchStatsEvent event = captor.getValue();
+        assertEquals(Constants.BATCH_STATS_FIELD_PENDING, event.getField());
+        assertEquals(1L, event.getDelta());
+        assertEquals(BATCH_ID, event.getBatchId());
+    }
+
+    @Test
+    void testEnrolBPWorkFlow_publishesPendingIncrementEvent_onSuccessfulEnrollment() throws Exception {
+        wfRequest = getRequest();
+        Map<String, Object> batchAttr = Map.of(
+                Constants.BATCH_ATTRIBUTES, "{\"currentBatchSize\":\"100\"}",
+                Constants.START_DATE, Instant.now(),
+                Constants.ENROLMENT_END_DATE, Instant.now().plusSeconds(3600),
+                Constants.NAME, "Test Batch"
+        );
+        when(cassandraOperation.getRecordsByProperties(
+                eq(Constants.KEYSPACE_SUNBIRD_COURSES), eq(Constants.TABLE_COURSE_BATCH), anyMap(), anyList()))
+                .thenReturn(List.of(batchAttr));
+        when(cassandraOperation.getRecordsByProperties(
+                eq(Constants.KEYSPACE_SUNBIRD_COURSES), eq(Constants.TABLE_ENROLMENT_BATCH_LOOKUP), anyMap(), anyList()))
+                .thenReturn(Collections.emptyList());
+        when(contentReadService.getServiceNameDetails(any()))
+                .thenReturn(Map.of("wfApprovalType", "", "primaryCategory", "Course"));
+        when(wfStatusRepo.findByApplicationId(any())).thenReturn(Collections.emptyList());
+        when(wfStatusRepo.save(any(WfStatusEntity.class))).thenReturn(new WfStatusEntity());
+        when(mapper.writeValueAsString(any())).thenReturn("[]");
+        when(configuration.getBpBatchStatsTopic()).thenReturn("bp-stats-topic");
+        when(configuration.getWorkflowApplicationTopic()).thenReturn("wf-topic");
+        doReturn(false).when(bpWorkFlowService).scheduleConflictCheck(any());
+        Response response = bpWorkFlowService.enrolBPWorkFlow(ROOT_ORG, ORG, wfRequest);
+        assertEquals(HttpStatus.OK, response.get(Constants.STATUS));
+        ArgumentCaptor<BatchStatsEvent> captor = ArgumentCaptor.forClass(BatchStatsEvent.class);
+        verify(producer).push(eq("bp-stats-topic"), captor.capture());
+        BatchStatsEvent event = captor.getValue();
+        assertEquals(Constants.BATCH_STATS_FIELD_PENDING, event.getField());
+        assertEquals(1L, event.getDelta());
+    }
+
 }

--- a/src/test/java/org/sunbird/workflow/service/BPWorkFlowServiceImplTest.java
+++ b/src/test/java/org/sunbird/workflow/service/BPWorkFlowServiceImplTest.java
@@ -1611,7 +1611,7 @@ class BPWorkFlowServiceImplTest {
     }
 
     @Test
-    void testUpdateBPWorkFlow_publishesPendingDecrementEvent_whenTransitionResultIsRejected() {
+    void testUpdateBPWorkFlow_publishesTwoBatchStatsEvents_whenTransitionResultIsRejected() {
         wfRequest = buildSkipValidationRequest();
         stubSkipValidationAndConflictCheck();
         when(configuration.getBpBatchStatsTopic()).thenReturn("bp-stats-topic");
@@ -1622,11 +1622,19 @@ class BPWorkFlowServiceImplTest {
         when(workflowservice.workflowTransition(any(), any(), any(), any(), any())).thenReturn(wfResponse);
         bpWorkFlowService.updateBPWorkFlow(ROOT_ORG, ORG, wfRequest, USER_ID, "role");
         ArgumentCaptor<BatchStatsEvent> captor = ArgumentCaptor.forClass(BatchStatsEvent.class);
-        verify(producer, times(1)).push(eq("bp-stats-topic"), captor.capture());
-        BatchStatsEvent event = captor.getValue();
-        assertEquals(Constants.BATCH_STATS_FIELD_PENDING, event.getField());
-        assertEquals(-1L, event.getDelta());
-        assertEquals(BATCH_ID, event.getBatchId());
+        verify(producer, times(2)).push(eq("bp-stats-topic"), captor.capture());
+        List<BatchStatsEvent> events = captor.getAllValues();
+        BatchStatsEvent pendingEvent = events.stream()
+                .filter(e -> Constants.BATCH_STATS_FIELD_PENDING.equals(e.getField()))
+                .findFirst().orElse(null);
+        assertNotNull(pendingEvent, "Expected pending decrement event");
+        assertEquals(-1L, pendingEvent.getDelta());
+        BatchStatsEvent rejectedEvent = events.stream()
+                .filter(e -> Constants.BATCH_STATS_FIELD_REJECTED.equals(e.getField()))
+                .findFirst().orElse(null);
+        assertNotNull(rejectedEvent, "Expected rejected increment event");
+        assertEquals(1L, rejectedEvent.getDelta());
+        assertEquals(BATCH_ID, rejectedEvent.getBatchId());
     }
 
     @Test

--- a/src/test/java/org/sunbird/workflow/service/BPWorkFlowServiceImplTest.java
+++ b/src/test/java/org/sunbird/workflow/service/BPWorkFlowServiceImplTest.java
@@ -1579,16 +1579,54 @@ class BPWorkFlowServiceImplTest {
     }
 
     @Test
-    void testUpdateBPWorkFlow_doesNotPublishBatchStats_whenTransitionStatusIsNotWithdrawn() {
+    void testUpdateBPWorkFlow_doesNotPublishBatchStats_whenTransitionStatusHasNoStatsEvent() {
         wfRequest = buildSkipValidationRequest();
         stubSkipValidationAndConflictCheck();
+        Map<String, Object> dataMap = new HashMap<>();
+        dataMap.put(Constants.STATUS, Constants.SEND_FOR_PC_APPROVAL);
+        Response wfResponse = new Response();
+        wfResponse.put(Constants.DATA, dataMap);
+        when(workflowservice.workflowTransition(any(), any(), any(), any(), any())).thenReturn(wfResponse);
+        bpWorkFlowService.updateBPWorkFlow(ROOT_ORG, ORG, wfRequest, USER_ID, "role");
+        verify(producer, never()).push(any(), any(BatchStatsEvent.class));
+    }
+
+    @Test
+    void testUpdateBPWorkFlow_publishesPendingDecrementEvent_whenTransitionResultIsApproved() {
+        wfRequest = buildSkipValidationRequest();
+        stubSkipValidationAndConflictCheck();
+        when(configuration.getBpBatchStatsTopic()).thenReturn("bp-stats-topic");
         Map<String, Object> dataMap = new HashMap<>();
         dataMap.put(Constants.STATUS, Constants.APPROVED_STATE);
         Response wfResponse = new Response();
         wfResponse.put(Constants.DATA, dataMap);
         when(workflowservice.workflowTransition(any(), any(), any(), any(), any())).thenReturn(wfResponse);
         bpWorkFlowService.updateBPWorkFlow(ROOT_ORG, ORG, wfRequest, USER_ID, "role");
-        verify(producer, never()).push(any(), any(BatchStatsEvent.class));
+        ArgumentCaptor<BatchStatsEvent> captor = ArgumentCaptor.forClass(BatchStatsEvent.class);
+        verify(producer, times(1)).push(eq("bp-stats-topic"), captor.capture());
+        BatchStatsEvent event = captor.getValue();
+        assertEquals(Constants.BATCH_STATS_FIELD_PENDING, event.getField());
+        assertEquals(-1L, event.getDelta());
+        assertEquals(BATCH_ID, event.getBatchId());
+    }
+
+    @Test
+    void testUpdateBPWorkFlow_publishesPendingDecrementEvent_whenTransitionResultIsRejected() {
+        wfRequest = buildSkipValidationRequest();
+        stubSkipValidationAndConflictCheck();
+        when(configuration.getBpBatchStatsTopic()).thenReturn("bp-stats-topic");
+        Map<String, Object> dataMap = new HashMap<>();
+        dataMap.put(Constants.STATUS, Constants.REJECTED);
+        Response wfResponse = new Response();
+        wfResponse.put(Constants.DATA, dataMap);
+        when(workflowservice.workflowTransition(any(), any(), any(), any(), any())).thenReturn(wfResponse);
+        bpWorkFlowService.updateBPWorkFlow(ROOT_ORG, ORG, wfRequest, USER_ID, "role");
+        ArgumentCaptor<BatchStatsEvent> captor = ArgumentCaptor.forClass(BatchStatsEvent.class);
+        verify(producer, times(1)).push(eq("bp-stats-topic"), captor.capture());
+        BatchStatsEvent event = captor.getValue();
+        assertEquals(Constants.BATCH_STATS_FIELD_PENDING, event.getField());
+        assertEquals(-1L, event.getDelta());
+        assertEquals(BATCH_ID, event.getBatchId());
     }
 
     @Test

--- a/src/test/java/org/sunbird/workflow/service/impl/BPWorkFlowServiceImplPrivateMethodTest.java
+++ b/src/test/java/org/sunbird/workflow/service/impl/BPWorkFlowServiceImplPrivateMethodTest.java
@@ -13,6 +13,7 @@ import org.sunbird.workflow.exception.InvalidDataInputException;
 import org.sunbird.workflow.models.*;
 import org.sunbird.workflow.postgres.entity.WfStatusEntity;
 import org.sunbird.workflow.postgres.repo.WfStatusRepo;
+import org.sunbird.workflow.producer.Producer;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -456,12 +457,15 @@ class BPWorkFlowServiceImplPrivateMethodTest {
         // Mock dependencies
         WfStatusRepo wfStatusRepo = mock(WfStatusRepo.class);
         ObjectMapper newMapper = mock(ObjectMapper.class);
-        Configuration configuration = mock(Configuration.class);
+        Configuration mockConfig = mock(Configuration.class);
+        Producer mockProducer = mock(Producer.class);
 
         // Inject mocks via reflection
         setPrivateField(service, "wfStatusRepo", wfStatusRepo);
         setPrivateField(service, "mapper", newMapper);
-        setPrivateField(service, "configuration", configuration);
+        setPrivateField(service, "configuration", mockConfig);
+        setPrivateField(service, "producer", mockProducer);
+        when(mockConfig.getBpBatchStatsTopic()).thenReturn("bp.batch.enrollment.stats");
 
         // Prepare test data
         String rootOrg = "rootOrg";

--- a/src/test/java/org/sunbird/workflow/service/impl/UserProfileWfServiceImplTest.java
+++ b/src/test/java/org/sunbird/workflow/service/impl/UserProfileWfServiceImplTest.java
@@ -676,15 +676,13 @@ class UserProfileWfServiceImplTest {
                 .thenReturn(successfulResponse)
                 .thenReturn(failedResponse);
 
-        when(mapper.writeValueAsString(any())).thenReturn("{}");
-
         Method method = UserProfileWfServiceImpl.class.getDeclaredMethod(
                 "updateUserProfileData", String.class, Map.class, List.class, Map.class);
         method.setAccessible(true);
 
         // SUCCESS CASE
         method.invoke(userProfileWfServiceImpl, userId, profileDetails, wfRequests, userDetails);
-        verify(redisCacheMgr).putInBasicProfileCache(anyString(), eq("{}"), anyInt());
+        verify(redisCacheMgr).deleteCache(Constants.USER_BASIC_PROFILE_REDIS_KEY_PREFIX + userId);
 
         // FAILURE CASE
         method.invoke(userProfileWfServiceImpl, userId, profileDetails, wfRequests, userDetails);


### PR DESCRIPTION
feat: add async batch enrollment stats tracking for Blended Programs

Introduces a Redis-backed enrollment statistics cache per batch, tracking `pending` and `withdrawn` counts via a Redis hash keyed at `bp:batch:enrollment:stats:<batchId>`.

Changes:
- BatchStatsEvent (new): lightweight Kafka payload carrying batchId, field name, and a signed delta (positive = increment, negative = decrement).
- BatchStatsConsumer (new): Kafka listener on `bp.batch.enrollment.stats` that routes events to increment/decrement the appropriate Redis hash field, decoupling Redis writes from the synchronous enrollment path.
- WorkflowRedisCacheMgr: refactored to constructor injection; added incrementBatchFieldCount(), decrementBatchFieldCount(), getBatchStats(), and a lazy-init helper (initBatchStatsFromDb()) that seeds the cache from the DB on first access, avoiding stale or missing data.
- WfStatusRepo: added countGroupedByStatusForApplicationId() to support lazy cache initialisation with a single DB round-trip.
- BPWorkFlowServiceImpl: publishes pending-increment events on admin and self-enrollment; publishes pending-decrement + withdrawn-increment on WITHDRAWN transitions and superseded nominations via a shared publishBatchStatsOnStatusChange() helper.
- Constants: added BP_BATCH_STATS_PREFIX, BATCH_STATS_FIELD_PENDING, BATCH_STATS_FIELD_WITHDRAWN, and BATCH_STATS_TERMINAL_STATUSES.
- Configuration: added bpBatchStatsTopic binding.
- application.properties: registered kafka.topics.bp.batch.stats.