### PR TITLE
KB-14009 | BE | Blended Program Enhancements | Learner TOC Page enhancement

### DIFF
--- a/src/main/java/org/sunbird/workflow/config/WorkflowRedisCacheMgr.java
+++ b/src/main/java/org/sunbird/workflow/config/WorkflowRedisCacheMgr.java
@@ -83,7 +83,14 @@ public class WorkflowRedisCacheMgr {
 
     /**
      * Increments the given field in the batch stats hash by 1.
-     * If the key does not exist, initialises it from the DB first (lazy init).
+     *
+     * On cache miss: initialises from DB and returns without applying a delta,
+     * because the Kafka event is always published AFTER the DB write — so the
+     * DB snapshot already reflects this state change. Applying +1 on top would
+     * double-count the record.
+     *
+     * On cache hit: the cache was built before this change arrived, so the
+     * delta is applied normally to keep the cache in sync.
      */
     public void incrementBatchFieldCount(String batchId, String field) {
         var key = Constants.BP_BATCH_STATS_PREFIX + batchId;
@@ -91,6 +98,8 @@ public class WorkflowRedisCacheMgr {
             jedis.select(configuration.getBpBatchStatsCacheIndex());
             if (!jedis.exists(key)) {
                 initBatchStatsFromDb(batchId, jedis, key);
+                logger.debug("Cache miss for batchId={}: initialised from DB (skipping increment for field={})", batchId, field);
+                return;
             }
             var updated = jedis.hincrBy(key, field, 1L);
             logger.debug("Incremented field={} for batchId={} newValue={}", field, batchId, updated);
@@ -101,14 +110,20 @@ public class WorkflowRedisCacheMgr {
 
     /**
      * Decrements the given field in the batch stats hash by 1.
-     * No-op if the key does not exist — avoids creating a stale entry on decrement.
+     *
+     * On cache miss: initialises from DB and returns without applying a delta,
+     * because the DB already reflects this state change (event published after
+     * DB write). Applying -1 on top would under-count the record.
+     *
+     * On cache hit: apply the delta normally to keep the cache in sync.
      */
     public void decrementBatchFieldCount(String batchId, String field) {
         var key = Constants.BP_BATCH_STATS_PREFIX + batchId;
         try (Jedis jedis = jedisPool.getResource()) {
             jedis.select(configuration.getBpBatchStatsCacheIndex());
             if (!jedis.exists(key)) {
-                logger.debug("Skipping decrement for field={} batchId={} — key not in cache", field, batchId);
+                initBatchStatsFromDb(batchId, jedis, key);
+                logger.debug("Cache miss for batchId={}: initialised from DB (skipping decrement for field={})", batchId, field);
                 return;
             }
             var updated = jedis.hincrBy(key, field, -1L);

--- a/src/test/java/org/sunbird/workflow/config/WorkflowRedisCacheMgrTest.java
+++ b/src/test/java/org/sunbird/workflow/config/WorkflowRedisCacheMgrTest.java
@@ -85,7 +85,7 @@ class WorkflowRedisCacheMgrTest {
 
 
     @Test
-    void increment_whenKeyMissing_initFromDbThenIncrBy() {
+    void increment_whenKeyMissing_initFromDbAndSkipIncrBy() {
         String batchId = "batch-002";
         String key = Constants.BP_BATCH_STATS_PREFIX + batchId;
         when(jedis.exists(key)).thenReturn(false);
@@ -104,7 +104,7 @@ class WorkflowRedisCacheMgrTest {
                 Constants.BATCH_STATS_FIELD_WITHDRAWN, "1",
                 Constants.BATCH_STATS_FIELD_REJECTED, "0"
         ));
-        verify(jedis).hincrBy(key, Constants.BATCH_STATS_FIELD_PENDING, 1L);
+        verify(jedis, never()).hincrBy(any(String.class), any(String.class), anyLong());
     }
 
     @Test
@@ -123,6 +123,7 @@ class WorkflowRedisCacheMgrTest {
                 Constants.BATCH_STATS_FIELD_WITHDRAWN, "0",
                 Constants.BATCH_STATS_FIELD_REJECTED, "5"
         ));
+        verify(jedis, never()).hincrBy(any(String.class), any(String.class), anyLong());
     }
 
     @Test
@@ -137,6 +138,7 @@ class WorkflowRedisCacheMgrTest {
                 Constants.BATCH_STATS_FIELD_WITHDRAWN, "0",
                 Constants.BATCH_STATS_FIELD_REJECTED, "0"
         ));
+        verify(jedis, never()).hincrBy(any(String.class), any(String.class), anyLong());
     }
 
     @Test
@@ -155,13 +157,21 @@ class WorkflowRedisCacheMgrTest {
     }
 
     @Test
-    void decrement_whenKeyMissing_isNoOpAndDoesNotInitFromDb() {
+    void decrement_whenKeyMissing_initFromDbAndSkipDecrement() {
         String batchId = "batch-006";
         String key = Constants.BP_BATCH_STATS_PREFIX + batchId;
         when(jedis.exists(key)).thenReturn(false);
+        List<Object[]> dbRows = new ArrayList<>();
+        dbRows.add(new Object[]{"WITHDRAWN", 1L});
+        when(wfStatusRepo.countGroupedByStatusForApplicationId(batchId)).thenReturn(dbRows);
         cacheMgr.decrementBatchFieldCount(batchId, Constants.BATCH_STATS_FIELD_PENDING);
         verify(jedis, never()).hincrBy(any(String.class), any(String.class), anyLong());
-        verify(wfStatusRepo, never()).countGroupedByStatusForApplicationId(any());
+        verify(wfStatusRepo).countGroupedByStatusForApplicationId(batchId);
+        verify(jedis).hmset(eq(key), argThat(m ->
+                "0".equals(m.get(Constants.BATCH_STATS_FIELD_PENDING)) &&
+                "1".equals(m.get(Constants.BATCH_STATS_FIELD_WITHDRAWN)) &&
+                "0".equals(m.get(Constants.BATCH_STATS_FIELD_REJECTED))
+        ));
     }
 
     @Test


### PR DESCRIPTION
fix: init cache from DB on miss instead of applying stale delta

On cache miss, both incrementBatchFieldCount and decrementBatchFieldCount now initialise from DB and return without applying a delta — the DB already reflects the change since events are published after DB writes. Previously, decrement was a no-op (leaving cache uninitialised) and increment double-counted by applying +1 on top of a fresh DB snapshot.

Tests updated to match the new behaviour.