### PR TITLE
KB-14009 | BE | Blended Program Enhancements | Learner TOC Page enhancement

### DIFF
--- a/src/main/java/org/sunbird/workflow/config/Constants.java
+++ b/src/main/java/org/sunbird/workflow/config/Constants.java
@@ -466,6 +466,7 @@ public class Constants {
 	public static final String BATCH_STATS_FIELD_PENDING = "pending";
 	public static final String BATCH_STATS_FIELD_WITHDRAWN = "withdrawn";
 	public static final String BATCH_STATS_FIELD_REJECTED = "rejected";
+	public static final String BATCH_STATS_FIELD_APPROVED = "approved";
 	public static final Set<String> BATCH_STATS_TERMINAL_STATUSES = Set.of(APPROVED_STATE, REJECTED, WITHDRAWN, REMOVED);
 
 }

--- a/src/main/java/org/sunbird/workflow/config/WorkflowRedisCacheMgr.java
+++ b/src/main/java/org/sunbird/workflow/config/WorkflowRedisCacheMgr.java
@@ -5,9 +5,12 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import org.sunbird.workflow.postgres.repo.WfStatusRepo;
+import org.sunbird.workflow.utils.CassandraOperation;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @Component
@@ -16,14 +19,17 @@ public class WorkflowRedisCacheMgr {
     private final JedisPool jedisPool;
     private final WfStatusRepo wfStatusRepo;
     private final Configuration configuration;
+    private final CassandraOperation cassandraOperation;
     private final Logger logger = LoggerFactory.getLogger(WorkflowRedisCacheMgr.class);
 
     public WorkflowRedisCacheMgr(@Qualifier("jedisWorkflowPopulationPool") JedisPool jedisPool,
                                  WfStatusRepo wfStatusRepo,
-                                 Configuration configuration) {
+                                 Configuration configuration,
+                                 CassandraOperation cassandraOperation) {
         this.jedisPool = jedisPool;
         this.wfStatusRepo = wfStatusRepo;
         this.configuration = configuration;
+        this.cassandraOperation = cassandraOperation;
     }
 
     public void put(String key, String value, int ttl, int index) {
@@ -49,9 +55,8 @@ public class WorkflowRedisCacheMgr {
 
     /**
      * Lazy-initialises the batch stats Redis hash from the DB.
-     * Queries wf_status grouped by current_status for the given batchId,
-     * tallies pending (any non-terminal status) and withdrawn counts,
-     * then writes both fields into the hash in a single HMSET.
+     * pending/withdrawn/rejected come from wf_status (PostgreSQL).
+     * approved comes from enrollment_batch_lookup (Cassandra) — source of truth for actual enrollments.
      */
     private void initBatchStatsFromDb(String batchId, Jedis jedis, String key) {
         logger.debug("Cache miss for batchId={}, initialising batch stats from DB", batchId);
@@ -72,13 +77,15 @@ public class WorkflowRedisCacheMgr {
                 rejected = count;
             }
         }
+        long approved = countActiveEnrollments(batchId);
         jedis.hmset(key, Map.of(
                 Constants.BATCH_STATS_FIELD_PENDING, String.valueOf(pending),
                 Constants.BATCH_STATS_FIELD_WITHDRAWN, String.valueOf(withdrawn),
-                Constants.BATCH_STATS_FIELD_REJECTED, String.valueOf(rejected)));
+                Constants.BATCH_STATS_FIELD_REJECTED, String.valueOf(rejected),
+                Constants.BATCH_STATS_FIELD_APPROVED, String.valueOf(approved)));
         jedis.expire(key, configuration.getBpBatchStatsCacheTtl());
-        logger.info("Batch stats cache initialised for batchId={} pending={} withdrawn={} rejected={} ttl={}s",
-                batchId, pending, withdrawn, rejected, configuration.getBpBatchStatsCacheTtl());
+        logger.info("Batch stats cache initialised for batchId={} pending={} withdrawn={} rejected={} approved={} ttl={}s",
+                batchId, pending, withdrawn, rejected, approved, configuration.getBpBatchStatsCacheTtl());
     }
 
     /**
@@ -149,5 +156,25 @@ public class WorkflowRedisCacheMgr {
             logger.error("Failed to read batch stats from cache for batchId={}", batchId, e);
             return Collections.emptyMap();
         }
+    }
+
+    /**
+     * Counts active (enrolled) participants for the given batchId from Cassandra
+     * enrollment_batch_lookup — the same source of truth used by sunbird-course-service.
+     */
+    private long countActiveEnrollments(String batchId) {
+        logger.info("BatchStats: countActiveEnrollments :: batchId={}", batchId);
+        Map<String, Object> propertyMap = new HashMap<>();
+        propertyMap.put(Constants.BATCH_ID, batchId);
+        List<Map<String, Object>> rows = cassandraOperation.getRecordsByProperties(
+                Constants.KEYSPACE_SUNBIRD_COURSES,
+                Constants.TABLE_ENROLMENT_BATCH_LOOKUP,
+                propertyMap,
+                List.of(Constants.ACTIVE));
+        long count = rows.stream()
+                .filter(r -> r != null && Boolean.TRUE.equals(r.get(Constants.ACTIVE)))
+                .count();
+        logger.info("BatchStats: countActiveEnrollments :: batchId={} totalRows={} activeCount={}", batchId, rows.size(), count);
+        return count;
     }
 }

--- a/src/test/java/org/sunbird/workflow/config/WorkflowRedisCacheMgrTest.java
+++ b/src/test/java/org/sunbird/workflow/config/WorkflowRedisCacheMgrTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.*;
 import org.sunbird.workflow.postgres.repo.WfStatusRepo;
+import org.sunbird.workflow.utils.CassandraOperation;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
@@ -28,6 +29,9 @@ class WorkflowRedisCacheMgrTest {
     private Configuration configuration;
 
     @Mock
+    private CassandraOperation cassandraOperation;
+
+    @Mock
     private Jedis jedis;
 
     private WorkflowRedisCacheMgr cacheMgr;
@@ -38,10 +42,13 @@ class WorkflowRedisCacheMgrTest {
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        cacheMgr = new WorkflowRedisCacheMgr(jedisPool, wfStatusRepo, configuration);
+        cacheMgr = new WorkflowRedisCacheMgr(jedisPool, wfStatusRepo, configuration, cassandraOperation);
         when(jedisPool.getResource()).thenReturn(jedis);
         when(configuration.getBpBatchStatsCacheTtl()).thenReturn(14400);
         when(configuration.getBpBatchStatsCacheIndex()).thenReturn(2);
+        // Default: no active enrollments in Cassandra → approved = 0
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), anyList()))
+                .thenReturn(Collections.emptyList());
     }
 
 
@@ -80,6 +87,7 @@ class WorkflowRedisCacheMgrTest {
         when(jedis.exists(key)).thenReturn(true);
         cacheMgr.incrementBatchFieldCount(batchId, Constants.BATCH_STATS_FIELD_PENDING);
         verify(wfStatusRepo, never()).countGroupedByStatusForApplicationId(any());
+        verify(cassandraOperation, never()).getRecordsByProperties(any(), any(), any(), any());
         verify(jedis).hincrBy(key, Constants.BATCH_STATS_FIELD_PENDING, 1L);
     }
 
@@ -90,7 +98,7 @@ class WorkflowRedisCacheMgrTest {
         String key = Constants.BP_BATCH_STATS_PREFIX + batchId;
         when(jedis.exists(key)).thenReturn(false);
         // ENROLL_IS_IN_PROGRESS is non-terminal → counts as pending
-        // APPROVED is terminal → skipped for pending
+        // APPROVED is terminal → skipped for pending; approved comes from Cassandra (empty → 0)
         // WITHDRAWN is terminal → counted as withdrawn
         List<Object[]> dbRows = new ArrayList<>();
         dbRows.add(new Object[]{"ENROLL_IS_IN_PROGRESS", 3L});
@@ -98,11 +106,12 @@ class WorkflowRedisCacheMgrTest {
         dbRows.add(new Object[]{"WITHDRAWN", 1L});
         when(wfStatusRepo.countGroupedByStatusForApplicationId(batchId)).thenReturn(dbRows);
         cacheMgr.incrementBatchFieldCount(batchId, Constants.BATCH_STATS_FIELD_PENDING);
-        // pending = 3, withdrawn = 1
+        // pending = 3, withdrawn = 1, rejected = 0, approved = 0 (Cassandra returned empty)
         verify(jedis).hmset(key, Map.of(
                 Constants.BATCH_STATS_FIELD_PENDING, "3",
                 Constants.BATCH_STATS_FIELD_WITHDRAWN, "1",
-                Constants.BATCH_STATS_FIELD_REJECTED, "0"
+                Constants.BATCH_STATS_FIELD_REJECTED, "0",
+                Constants.BATCH_STATS_FIELD_APPROVED, "0"
         ));
         verify(jedis, never()).hincrBy(any(String.class), any(String.class), anyLong());
     }
@@ -121,7 +130,8 @@ class WorkflowRedisCacheMgrTest {
         verify(jedis).hmset(key, Map.of(
                 Constants.BATCH_STATS_FIELD_PENDING, "0",
                 Constants.BATCH_STATS_FIELD_WITHDRAWN, "0",
-                Constants.BATCH_STATS_FIELD_REJECTED, "5"
+                Constants.BATCH_STATS_FIELD_REJECTED, "5",
+                Constants.BATCH_STATS_FIELD_APPROVED, "0"
         ));
         verify(jedis, never()).hincrBy(any(String.class), any(String.class), anyLong());
     }
@@ -136,7 +146,8 @@ class WorkflowRedisCacheMgrTest {
         verify(jedis).hmset(key, Map.of(
                 Constants.BATCH_STATS_FIELD_PENDING, "0",
                 Constants.BATCH_STATS_FIELD_WITHDRAWN, "0",
-                Constants.BATCH_STATS_FIELD_REJECTED, "0"
+                Constants.BATCH_STATS_FIELD_REJECTED, "0",
+                Constants.BATCH_STATS_FIELD_APPROVED, "0"
         ));
         verify(jedis, never()).hincrBy(any(String.class), any(String.class), anyLong());
     }
@@ -170,7 +181,8 @@ class WorkflowRedisCacheMgrTest {
         verify(jedis).hmset(eq(key), argThat(m ->
                 "0".equals(m.get(Constants.BATCH_STATS_FIELD_PENDING)) &&
                 "1".equals(m.get(Constants.BATCH_STATS_FIELD_WITHDRAWN)) &&
-                "0".equals(m.get(Constants.BATCH_STATS_FIELD_REJECTED))
+                "0".equals(m.get(Constants.BATCH_STATS_FIELD_REJECTED)) &&
+                "0".equals(m.get(Constants.BATCH_STATS_FIELD_APPROVED))
         ));
     }
 
@@ -190,6 +202,7 @@ class WorkflowRedisCacheMgrTest {
         Map<String, String> result = cacheMgr.getBatchStats(batchId);
         assertEquals(expected, result);
         verify(wfStatusRepo, never()).countGroupedByStatusForApplicationId(any());
+        verify(cassandraOperation, never()).getRecordsByProperties(any(), any(), any(), any());
     }
 
     @Test
@@ -206,7 +219,8 @@ class WorkflowRedisCacheMgrTest {
         verify(jedis).hmset(eq(key), argThat(m ->
                 "5".equals(m.get(Constants.BATCH_STATS_FIELD_PENDING)) &&
                 "0".equals(m.get(Constants.BATCH_STATS_FIELD_WITHDRAWN)) &&
-                "0".equals(m.get(Constants.BATCH_STATS_FIELD_REJECTED))
+                "0".equals(m.get(Constants.BATCH_STATS_FIELD_REJECTED)) &&
+                "0".equals(m.get(Constants.BATCH_STATS_FIELD_APPROVED))
         ));
         assertEquals(expected, result);
     }
@@ -217,7 +231,6 @@ class WorkflowRedisCacheMgrTest {
         Map<String, String> result = cacheMgr.getBatchStats("batch-009");
         assertEquals(Collections.emptyMap(), result);
     }
-
 
     @Test
     void increment_withdrawnStatusInDb_isCountedAsWithdrawnNotPending() {
@@ -233,6 +246,7 @@ class WorkflowRedisCacheMgrTest {
         assertEquals("3", stored.get(Constants.BATCH_STATS_FIELD_WITHDRAWN));
         assertEquals("0", stored.get(Constants.BATCH_STATS_FIELD_PENDING));
         assertEquals("0", stored.get(Constants.BATCH_STATS_FIELD_REJECTED));
+        assertEquals("0", stored.get(Constants.BATCH_STATS_FIELD_APPROVED));
     }
 
     @Test
@@ -250,5 +264,27 @@ class WorkflowRedisCacheMgrTest {
         assertEquals("4", stored.get(Constants.BATCH_STATS_FIELD_REJECTED));
         assertEquals("2", stored.get(Constants.BATCH_STATS_FIELD_PENDING));
         assertEquals("0", stored.get(Constants.BATCH_STATS_FIELD_WITHDRAWN));
+        assertEquals("0", stored.get(Constants.BATCH_STATS_FIELD_APPROVED));
+    }
+
+    @Test
+    void increment_whenCassandraReturnsActiveEnrollments_approvedCountReflectsIt() {
+        String batchId = "batch-012";
+        String key = Constants.BP_BATCH_STATS_PREFIX + batchId;
+        when(jedis.exists(key)).thenReturn(false);
+        when(wfStatusRepo.countGroupedByStatusForApplicationId(batchId)).thenReturn(Collections.emptyList());
+        // Cassandra returns 3 active + 1 inactive enrollment
+        List<Map<String, Object>> cassandraRows = new ArrayList<>();
+        cassandraRows.add(Map.of(Constants.ACTIVE, true));
+        cassandraRows.add(Map.of(Constants.ACTIVE, true));
+        cassandraRows.add(Map.of(Constants.ACTIVE, true));
+        cassandraRows.add(Map.of(Constants.ACTIVE, false));
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), anyList()))
+                .thenReturn(cassandraRows);
+        cacheMgr.incrementBatchFieldCount(batchId, Constants.BATCH_STATS_FIELD_APPROVED);
+        verify(jedis).hmset(eq(key), argThat(m ->
+                "3".equals(m.get(Constants.BATCH_STATS_FIELD_APPROVED)) &&
+                "0".equals(m.get(Constants.BATCH_STATS_FIELD_PENDING))
+        ));
     }
 }


### PR DESCRIPTION
feat(batch-stats): track approved count in Redis for blended program batches KB-14009 | BE | Blended Program Enhancements | Learner TOC Page enhancement#
- Add BATCH_STATS_FIELD_APPROVED constant
- Inject CassandraOperation into WorkflowRedisCacheMgr; count active enrollments from enrollment_batch_lookup (same source of truth as course-service) during lazy init
- Update tests: add CassandraOperation mock, include approved field in all hmset verifications