### PR TITLE
KB-14343 | BE | Script to populate REDIS value for user count against batches

### DIFF
--- a/src/main/java/org/sunbird/workflow/config/Configuration.java
+++ b/src/main/java/org/sunbird/workflow/config/Configuration.java
@@ -299,6 +299,21 @@ public class Configuration {
     @Value("${bp.batch.stats.cache.index}")
     private int bpBatchStatsCacheIndex;
 
+    @Value("${bp.batch.stats.sync.db.chunk.size:50}")
+    private int bpBatchStatsSyncDbChunkSize;
+
+    @Value("${sb.search.service.host}")
+    private String sbSearchServiceHost;
+
+    @Value("${sb.composite.v4.search}")
+    private String sbCompositeV4Search;
+
+    @Value("${bp.batch.stats.sync.redis.pipeline.size:100}")
+    private int bpBatchStatsSyncRedisPipelineSize;
+
+    @Value("${bp.batch.stats.sync.page.size:100}")
+    private int bpBatchStatsSyncPageSize;
+
     public String getAdminBlendedProgramEnrolEndPoint() {
         return adminBlendedProgramEnrolEndPoint;
     }
@@ -1018,4 +1033,45 @@ public class Configuration {
     public void setBpBatchStatsCacheIndex(int bpBatchStatsCacheIndex) {
         this.bpBatchStatsCacheIndex = bpBatchStatsCacheIndex;
     }
+
+    public int getBpBatchStatsSyncDbChunkSize() {
+        return bpBatchStatsSyncDbChunkSize;
+    }
+
+    public void setBpBatchStatsSyncDbChunkSize(int bpBatchStatsSyncDbChunkSize) {
+        this.bpBatchStatsSyncDbChunkSize = bpBatchStatsSyncDbChunkSize;
+    }
+
+    public String getSbSearchServiceHost() {
+        return sbSearchServiceHost;
+    }
+
+    public void setSbSearchServiceHost(String sbSearchServiceHost) {
+        this.sbSearchServiceHost = sbSearchServiceHost;
+    }
+
+    public String getSbCompositeV4Search() {
+        return sbCompositeV4Search;
+    }
+
+    public void setSbCompositeV4Search(String sbCompositeV4Search) {
+        this.sbCompositeV4Search = sbCompositeV4Search;
+    }
+
+    public int getBpBatchStatsSyncRedisPipelineSize() {
+        return bpBatchStatsSyncRedisPipelineSize;
+    }
+
+    public void setBpBatchStatsSyncRedisPipelineSize(int bpBatchStatsSyncRedisPipelineSize) {
+        this.bpBatchStatsSyncRedisPipelineSize = bpBatchStatsSyncRedisPipelineSize;
+    }
+
+    public int getBpBatchStatsSyncPageSize() {
+        return bpBatchStatsSyncPageSize;
+    }
+
+    public void setBpBatchStatsSyncPageSize(int bpBatchStatsSyncPageSize) {
+        this.bpBatchStatsSyncPageSize = bpBatchStatsSyncPageSize;
+    }
+
 }

--- a/src/main/java/org/sunbird/workflow/config/Constants.java
+++ b/src/main/java/org/sunbird/workflow/config/Constants.java
@@ -468,5 +468,16 @@ public class Constants {
 	public static final String BATCH_STATS_FIELD_REJECTED = "rejected";
 	public static final String BATCH_STATS_FIELD_APPROVED = "approved";
 	public static final Set<String> BATCH_STATS_TERMINAL_STATUSES = Set.of(APPROVED_STATE, REJECTED, WITHDRAWN, REMOVED);
+	public static final String CONTENT_TYPE_FIELD = "contentType";
+	public static final String COURSE = "Course";
+	public static final String COURSE_CATEGORY = "courseCategory";
+	public static final String BLENDED_PROGRAM_CATEGORY = "blended program";
+	public static final String LIVE = "Live";
+	public static final String AVG_RATING = "avgRating";
+	public static final String CREATED_ON = "createdOn";
+	public static final String DESC = "desc";
+	public static final String BATCHES = "batches";
+	public static final String FACETS = "facets";
+	public static final String SORT_BY = "sort_by";
 
 }

--- a/src/main/java/org/sunbird/workflow/config/WorkflowRedisCacheMgr.java
+++ b/src/main/java/org/sunbird/workflow/config/WorkflowRedisCacheMgr.java
@@ -1,5 +1,7 @@
 package org.sunbird.workflow.config;
 
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -8,10 +10,14 @@ import org.sunbird.workflow.postgres.repo.WfStatusRepo;
 import org.sunbird.workflow.utils.CassandraOperation;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Pipeline;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Component
 public class WorkflowRedisCacheMgr {
@@ -176,5 +182,136 @@ public class WorkflowRedisCacheMgr {
                 .count();
         logger.info("BatchStats: countActiveEnrollments :: batchId={} totalRows={} activeCount={}", batchId, rows.size(), count);
         return count;
+    }
+
+    /**
+     * Bulk warm-up: initialises Redis stats for a chunk of batchIds in 1 PG + 1 Cassandra query.
+     * Only processes batchIds whose key has expired (cache miss); live keys are untouched.
+     * Called by the sync job which partitions all batch IDs into configurable-sized chunks.
+     */
+    public void bulkInitBatchStats(List<String> batchIds) {
+        try (Jedis jedis = jedisPool.getResource()) {
+            jedis.select(configuration.getBpBatchStatsCacheIndex());
+            List<String> missing = findMissingBatchIds(batchIds, jedis);
+            if (CollectionUtils.isEmpty(missing)) {
+                logger.info("BatchStats: bulkInitBatchStats :: all {} keys still live, skipping", batchIds.size());
+                return;
+            }
+            logger.info("BatchStats: bulkInitBatchStats :: missingCount={} of chunkSize={}", missing.size(), batchIds.size());
+            Map<String, long[]> pgStats = buildPgStatsPerBatch(wfStatusRepo.countGroupedByStatusForApplicationIds(missing));
+            Map<String, Long> approvedMap = fetchApprovedCountsFromCassandra(missing);
+            writeStatsToRedis(missing, pgStats, approvedMap, jedis);
+            logger.info("BatchStats: bulkInitBatchStats :: initialized {} Redis keys", missing.size());
+        } catch (Exception e) {
+            logger.error("BatchStats: bulkInitBatchStats :: error for chunk of size={}", batchIds.size(), e);
+        }
+    }
+
+    /**
+     * Aggregates raw wf_status rows — each row is [application_id, current_status, count] —
+     * into a map of batchId → long[3] where indices are [pending, withdrawn, rejected].
+     * Non-terminal statuses (anything not in BATCH_STATS_TERMINAL_STATUSES) contribute to pending.
+     */
+    private Map<String, long[]> buildPgStatsPerBatch(List<Object[]> rows) {
+        Map<String, long[]> statsMap = new HashMap<>();
+        rows.forEach(row -> {
+            String batchId = (String) row[0];
+            String status = (String) row[1];
+            long count = ((Number) row[2]).longValue();
+            long[] stats = statsMap.computeIfAbsent(batchId, k -> new long[3]);
+            if (!Constants.BATCH_STATS_TERMINAL_STATUSES.contains(status)) stats[0] += count;
+            if (Constants.WITHDRAWN.equalsIgnoreCase(status)) stats[1] = count;
+            if (Constants.REJECTED.equalsIgnoreCase(status)) stats[2] = count;
+        });
+        logger.debug("BatchStats: buildPgStatsPerBatch :: processedRows={} distinctBatches={}", rows.size(), statsMap.size());
+        return statsMap;
+    }
+
+    /**
+     * Checks which batch stat keys are missing in Redis using a single pipeline round-trip,
+     * avoiding one EXISTS call per batch ID.
+     */
+    private List<String> findMissingBatchIds(List<String> batchIds, Jedis jedis) {
+        Pipeline pipeline = jedis.pipelined();
+        List<redis.clients.jedis.Response<Boolean>> responses = batchIds.stream()
+                .map(id -> pipeline.exists(Constants.BP_BATCH_STATS_PREFIX + id))
+                .toList();
+        pipeline.sync();
+        List<String> missing = IntStream.range(0, batchIds.size())
+                .filter(i -> !responses.get(i).get())
+                .mapToObj(batchIds::get)
+                .toList();
+        logger.debug("BatchStats: findMissingBatchIds :: checked={} missing={}", batchIds.size(), missing.size());
+        return missing;
+    }
+
+    /**
+     * Fetches enrollment_batch_lookup rows for all given batch IDs in a single Cassandra IN query
+     * and counts active=true rows per batch ID to produce the approved count.
+     */
+    private Map<String, Long> fetchApprovedCountsFromCassandra(List<String> batchIds) {
+        Map<String, Object> propertyMap = new HashMap<>();
+        propertyMap.put(Constants.BATCH_ID, batchIds);
+        List<Map<String, Object>> rows = cassandraOperation.getRecordsByProperties(
+                Constants.KEYSPACE_SUNBIRD_COURSES,
+                Constants.TABLE_ENROLMENT_BATCH_LOOKUP,
+                propertyMap,
+                List.of(Constants.BATCH_ID_KEY, Constants.ACTIVE));
+        Map<String, Long> approvedMap = rows.stream()
+                .filter(r -> Boolean.TRUE.equals(r.get(Constants.ACTIVE)))
+                .filter(r -> StringUtils.isNotBlank((String) r.get(Constants.BATCH_ID_KEY)))
+                .collect(Collectors.groupingBy(r -> (String) r.get(Constants.BATCH_ID_KEY), Collectors.counting()));
+        logger.info("BatchStats: fetchApprovedCountsFromCassandra :: queriedBatches={} totalRows={} batchesWithActiveEnrollments={}", batchIds.size(), rows.size(), approvedMap.size());
+        return approvedMap;
+    }
+
+    /**
+     * Partitions batchIds into sub-chunks of bp.batch.stats.sync.redis.pipeline.size
+     * and flushes each sub-chunk in a single pipeline round-trip, decoupling Redis pipeline
+     * size from the DB chunk size so both can be tuned independently.
+     */
+    private void writeStatsToRedis(List<String> batchIds, Map<String, long[]> pgStats,
+                                   Map<String, Long> approvedMap, Jedis jedis) {
+        int pipelineSize = configuration.getBpBatchStatsSyncRedisPipelineSize();
+        int totalPipelines = (int) Math.ceil((double) batchIds.size() / pipelineSize);
+        logger.info("BatchStats: writeStatsToRedis :: started totalKeys={} pipelineSize={} totalPipelines={}", batchIds.size(), pipelineSize, totalPipelines);
+        IntStream.range(0, totalPipelines).forEach(i -> {
+            List<String> subChunk = batchIds.subList(i * pipelineSize, Math.min((i + 1) * pipelineSize, batchIds.size()));
+            logger.info("BatchStats: writeStatsToRedis :: pipeline {}/{} keys={}", i + 1, totalPipelines, subChunk.size());
+            flushPipeline(subChunk, pgStats, approvedMap, jedis);
+        });
+        logger.info("BatchStats: writeStatsToRedis :: completed totalKeysFlushed={} totalPipelines={}", batchIds.size(), totalPipelines);
+    }
+
+    /**
+     * Writes hmset + expire for each batch ID in a single pipeline round-trip.
+     * Defaults to zero counts for any batch absent from the DB result maps.
+     */
+    private void flushPipeline(List<String> subChunk, Map<String, long[]> pgStats,
+                               Map<String, Long> approvedMap, Jedis jedis) {
+        Pipeline pipeline = jedis.pipelined();
+        List<String> toWrite = subChunk.stream()
+                .filter(batchId -> {
+                    long[] s = pgStats.getOrDefault(batchId, new long[3]);
+                    long approved = approvedMap.getOrDefault(batchId, 0L);
+                    boolean hasActivity = s[0] != 0 || s[1] != 0 || s[2] != 0 || approved != 0;
+                    if (!hasActivity) logger.debug("BatchStats: flushPipeline :: skipping batchId={} all counts are zero", batchId);
+                    return hasActivity;
+                })
+                .toList();
+        toWrite.forEach(batchId -> {
+            long[] s = pgStats.getOrDefault(batchId, new long[3]);
+            long approved = approvedMap.getOrDefault(batchId, 0L);
+            String key = Constants.BP_BATCH_STATS_PREFIX + batchId;
+            pipeline.hmset(key, Map.of(
+                    Constants.BATCH_STATS_FIELD_PENDING, String.valueOf(s[0]),
+                    Constants.BATCH_STATS_FIELD_WITHDRAWN, String.valueOf(s[1]),
+                    Constants.BATCH_STATS_FIELD_REJECTED, String.valueOf(s[2]),
+                    Constants.BATCH_STATS_FIELD_APPROVED, String.valueOf(approved)));
+            pipeline.expire(key, configuration.getBpBatchStatsCacheTtl());
+            logger.debug("BatchStats: flushPipeline :: queued batchId={} pending={} withdrawn={} rejected={} approved={}", batchId, s[0], s[1], s[2], approved);
+        });
+        pipeline.sync();
+        logger.debug("BatchStats: flushPipeline :: synced={} skipped={} in subChunk={}", toWrite.size(), subChunk.size() - toWrite.size(), subChunk.size());
     }
 }

--- a/src/main/java/org/sunbird/workflow/controller/BpBatchStatsSyncController.java
+++ b/src/main/java/org/sunbird/workflow/controller/BpBatchStatsSyncController.java
@@ -1,0 +1,32 @@
+package org.sunbird.workflow.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.sunbird.workflow.config.Constants;
+import org.sunbird.workflow.models.Response;
+import org.sunbird.workflow.service.BpBatchStatsSyncService;
+
+@RestController
+@RequestMapping("/v1/blendedprogram/batch/stats")
+public class BpBatchStatsSyncController {
+
+    private final BpBatchStatsSyncService bpBatchStatsSyncService;
+
+    public BpBatchStatsSyncController(BpBatchStatsSyncService bpBatchStatsSyncService) {
+        this.bpBatchStatsSyncService = bpBatchStatsSyncService;
+    }
+
+    /**
+     * Triggers a Redis warm-up for all live blended program batches whose stats key has expired.
+     * Fetches batch IDs from the search service, processes them in configurable chunks,
+     * and re-initialises the Redis hash only for expired keys. Live keys are left untouched.
+     */
+    @PostMapping("/sync")
+    public ResponseEntity<Response> syncBatchCountsToRedis() {
+        Response response = bpBatchStatsSyncService.syncBatchCountsToRedis();
+        return new ResponseEntity<>(response, (HttpStatus) response.get(Constants.STATUS));
+    }
+}

--- a/src/main/java/org/sunbird/workflow/postgres/repo/WfStatusRepo.java
+++ b/src/main/java/org/sunbird/workflow/postgres/repo/WfStatusRepo.java
@@ -166,5 +166,8 @@ public interface WfStatusRepo extends JpaRepository<WfStatusEntity, String> {
 
     @Query(value = "select * from wingspan.wf_status where userid = ?1 and service_name = ?2 order by lastupdated_on desc", nativeQuery = true)
     List<WfStatusEntity> findByUserIdAndServiceNameOrderByLastUpdatedOnDesc(String userId, String serviceName);
+
+    @Query(value = "SELECT application_id, current_status, COUNT(*) FROM wingspan.wf_status WHERE application_id IN :applicationIds GROUP BY application_id, current_status", nativeQuery = true)
+    List<Object[]> countGroupedByStatusForApplicationIds(@Param("applicationIds") List<String> applicationIds);
 }
 

--- a/src/main/java/org/sunbird/workflow/service/BpBatchStatsSyncService.java
+++ b/src/main/java/org/sunbird/workflow/service/BpBatchStatsSyncService.java
@@ -1,0 +1,15 @@
+package org.sunbird.workflow.service;
+
+import org.sunbird.workflow.models.Response;
+
+public interface BpBatchStatsSyncService {
+
+    /**
+     * Fetches all live blended programs from the search service, extracts batch IDs,
+     * and restores the enrollment stats in Redis for any batch whose key has expired.
+     * Batches whose key still exists in Redis are left untouched.
+     *
+     * @return Response containing count of batches initialised
+     */
+    Response syncBatchCountsToRedis();
+}

--- a/src/main/java/org/sunbird/workflow/service/ContentSearchService.java
+++ b/src/main/java/org/sunbird/workflow/service/ContentSearchService.java
@@ -1,0 +1,15 @@
+package org.sunbird.workflow.service;
+
+import java.util.Map;
+
+public interface ContentSearchService {
+
+    /**
+     * Fetches batch details for all live blended programs from the composite v4 search service.
+     *
+     * @param limit  - number of results to fetch
+     * @param offset - pagination offset
+     * @return result map containing content (with batches) and count
+     */
+    Map<String, Object> getBlendedProgramBatchDetails(int limit, int offset);
+}

--- a/src/main/java/org/sunbird/workflow/service/impl/BpBatchStatsSyncServiceImpl.java
+++ b/src/main/java/org/sunbird/workflow/service/impl/BpBatchStatsSyncServiceImpl.java
@@ -1,0 +1,117 @@
+package org.sunbird.workflow.service.impl;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.commons.collections.MapUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.sunbird.workflow.config.Configuration;
+import org.sunbird.workflow.config.Constants;
+import org.sunbird.workflow.config.WorkflowRedisCacheMgr;
+import org.sunbird.workflow.models.Response;
+import org.sunbird.workflow.service.BpBatchStatsSyncService;
+import org.sunbird.workflow.service.ContentSearchService;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.IntStream;
+
+@Service
+public class BpBatchStatsSyncServiceImpl implements BpBatchStatsSyncService {
+
+    private static final Logger logger = LoggerFactory.getLogger(BpBatchStatsSyncServiceImpl.class);
+
+    private final ContentSearchService contentSearchService;
+    private final WorkflowRedisCacheMgr workflowRedisCacheMgr;
+    private final Configuration configuration;
+
+    public BpBatchStatsSyncServiceImpl(ContentSearchService contentSearchService,
+                                       WorkflowRedisCacheMgr workflowRedisCacheMgr,
+                                       Configuration configuration) {
+        this.contentSearchService = contentSearchService;
+        this.workflowRedisCacheMgr = workflowRedisCacheMgr;
+        this.configuration = configuration;
+    }
+
+    /**
+     * Entry point for the batch stats sync job.
+     * Fetches all live blended program batch IDs, partitions them into configurable chunks,
+     * and delegates each chunk to WorkflowRedisCacheMgr for cache warm-up.
+     * Keys that are still live in Redis are skipped; only expired keys are re-initialised.
+     */
+    @Override
+    public Response syncBatchCountsToRedis() {
+        logger.info("BpBatchStatsSyncService :: syncBatchCountsToRedis :: started");
+        List<String> batchIds = fetchAllBatchIds();
+        int chunkSize = configuration.getBpBatchStatsSyncDbChunkSize();
+        int totalChunks = (int) Math.ceil((double) batchIds.size() / chunkSize);
+        logger.info("BpBatchStatsSyncService :: syncBatchCountsToRedis :: totalBatchIds={} chunkSize={} totalChunks={}", batchIds.size(), chunkSize, totalChunks);
+        IntStream.range(0, totalChunks)
+                .mapToObj(i -> batchIds.subList(i * chunkSize, Math.min((i + 1) * chunkSize, batchIds.size())))
+                .forEach(workflowRedisCacheMgr::bulkInitBatchStats);
+        logger.info("BpBatchStatsSyncService :: syncBatchCountsToRedis :: completed batchesProcessed={}", batchIds.size());
+        Response response = new Response();
+        response.put("batchesProcessed", batchIds.size());
+        response.put(Constants.STATUS, HttpStatus.OK);
+        return response;
+    }
+
+    /**
+     * Paginates through all live blended programs via the composite search service
+     * and collects every batch ID found in each program's batches field.
+     */
+    private List<String> fetchAllBatchIds() {
+        List<String> allBatchIds = new ArrayList<>();
+        int offset = 0;
+        int totalCount = Integer.MAX_VALUE;
+        int pageSize = configuration.getBpBatchStatsSyncPageSize();
+        while (offset < totalCount) {
+            Map<String, Object> result = contentSearchService.getBlendedProgramBatchDetails(pageSize, offset);
+            totalCount = extractTotalCount(result);
+            List<Map<String, Object>> programs = extractPrograms(result);
+            logger.debug("BpBatchStatsSyncService :: fetchAllBatchIds :: offset={} totalCount={} programsOnPage={}", offset, totalCount, programs.size());
+            if (programs.isEmpty()) break;
+            allBatchIds.addAll(extractBatchIds(programs));
+            offset += pageSize;
+        }
+        logger.info("BpBatchStatsSyncService :: fetchAllBatchIds :: totalBatchIds={}", allBatchIds.size());
+        return allBatchIds;
+    }
+
+    /**
+     * Extracts the program list from a composite search result.
+     * Returns an empty list when the result map is absent or the content field is missing.
+     */
+    private List<Map<String, Object>> extractPrograms(Map<String, Object> result) {
+        if (MapUtils.isEmpty(result)) return Collections.emptyList();
+        List<Map<String, Object>> programs = (List<Map<String, Object>>) result.get(Constants.CONTENT);
+        return CollectionUtils.isNotEmpty(programs) ? programs : Collections.emptyList();
+    }
+
+    /**
+     * Reads the total record count from a composite search result.
+     * Returns 0 on an empty result to terminate the pagination loop.
+     */
+    private int extractTotalCount(Map<String, Object> result) {
+        if (MapUtils.isEmpty(result)) return 0;
+        return ((Number) result.getOrDefault("count", 0)).intValue();
+    }
+
+    /**
+     * Flattens each program's batches list into a stream of non-blank batch IDs.
+     * Programs with a missing or empty batches field are skipped entirely.
+     */
+    private List<String> extractBatchIds(List<Map<String, Object>> programs) {
+        return programs.stream()
+                .filter(p -> CollectionUtils.isNotEmpty((Collection<?>) p.get(Constants.BATCHES)))
+                .flatMap(p -> ((List<Map<String, Object>>) p.get(Constants.BATCHES)).stream())
+                .map(b -> (String) b.get(Constants.BATCH_ID))
+                .filter(StringUtils::isNotBlank)
+                .toList();
+    }
+}

--- a/src/main/java/org/sunbird/workflow/service/impl/ContentSearchServiceImpl.java
+++ b/src/main/java/org/sunbird/workflow/service/impl/ContentSearchServiceImpl.java
@@ -1,0 +1,74 @@
+package org.sunbird.workflow.service.impl;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.sunbird.workflow.config.Configuration;
+import org.sunbird.workflow.config.Constants;
+import org.sunbird.workflow.service.ContentSearchService;
+
+import org.apache.commons.collections.MapUtils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+@Service
+public class ContentSearchServiceImpl implements ContentSearchService {
+
+    private static final Logger logger = LoggerFactory.getLogger(ContentSearchServiceImpl.class);
+
+    private final Configuration configuration;
+    private final RequestServiceImpl requestServiceImpl;
+
+    public ContentSearchServiceImpl(Configuration configuration, RequestServiceImpl requestServiceImpl) {
+        this.configuration = configuration;
+        this.requestServiceImpl = requestServiceImpl;
+    }
+
+    /**
+     * Fetches a paginated list of live blended programs from the composite search service,
+     * requesting only the batches field. Used by the sync job to discover all active batch IDs.
+     * Returns the raw result map (containing count and content) or an empty map on failure.
+     */
+    @SuppressWarnings("unchecked")
+    @Override
+    public Map<String, Object> getBlendedProgramBatchDetails(int limit, int offset) {
+        try {
+            StringBuilder url = new StringBuilder(configuration.getSbSearchServiceHost())
+                    .append(configuration.getSbCompositeV4Search());
+            Map<String, Object> filters = new HashMap<>();
+            filters.put(Constants.CONTENT_TYPE_FIELD, Collections.singletonList(Constants.COURSE));
+            filters.put(Constants.COURSE_CATEGORY, Collections.singletonList(Constants.BLENDED_PROGRAM_CATEGORY));
+            filters.put(Constants.STATUS, Collections.singletonList(Constants.LIVE));
+            filters.put(Constants.AVG_RATING, new HashMap<>());
+            Map<String, Object> sortBy = new HashMap<>();
+            sortBy.put(Constants.CREATED_ON, Constants.DESC);
+            Map<String, Object> request = new HashMap<>();
+            request.put(Constants.FILTERS, filters);
+            request.put(Constants.FIELDS, Collections.singletonList(Constants.BATCHES));
+            request.put(Constants.FACETS, Collections.emptyList());
+            request.put(Constants.QUERY, "");
+            request.put(Constants.LIMIT, limit);
+            request.put(Constants.OFFSET, offset);
+            request.put(Constants.SORT_BY, sortBy);
+            Map<String, Object> requestBody = new HashMap<>();
+            requestBody.put(Constants.REQUEST, request);
+            logger.info("ContentSearchService :: getBlendedProgramBatchDetails :: url={} limit={} offset={}", url, limit, offset);
+            Map<String, Object> response = (Map<String, Object>) requestServiceImpl.fetchResultUsingPost(
+                    url, requestBody, Map.class, null);
+            if (MapUtils.isNotEmpty(response) && Constants.OK.equalsIgnoreCase((String) response.get(Constants.RESPONSE_CODE))) {
+                Map<String, Object> result = (Map<String, Object>) response.get(Constants.RESULT);
+                if (MapUtils.isNotEmpty(result)) {
+                    logger.info("ContentSearchService :: getBlendedProgramBatchDetails :: responseCode=OK count={}", result.get("count"));
+                    return result;
+                }
+            }
+            logger.warn("ContentSearchService :: getBlendedProgramBatchDetails :: responseCode={} empty or failed response",
+                    MapUtils.isNotEmpty(response) ? response.get(Constants.RESPONSE_CODE) : "null");
+        } catch (Exception e) {
+            logger.error("ContentSearchService :: getBlendedProgramBatchDetails :: limit={} offset={} error", limit, offset, e);
+        }
+        return Collections.emptyMap();
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -184,3 +184,9 @@ sunbird_time_zone=Asia/Kolkata
 
 bp.batch.stats.cache.ttl=14400
 bp.batch.stats.cache.index=2
+bp.batch.stats.sync.db.chunk.size=50
+bp.batch.stats.sync.redis.pipeline.size=100
+bp.batch.stats.sync.page.size=100
+#search-service
+sb.search.service.host=http://search-service:9000
+sb.composite.v4.search=/v4/search

--- a/src/test/java/org/sunbird/workflow/config/WorkflowRedisCacheMgrTest.java
+++ b/src/test/java/org/sunbird/workflow/config/WorkflowRedisCacheMgrTest.java
@@ -7,9 +7,11 @@ import org.sunbird.workflow.postgres.repo.WfStatusRepo;
 import org.sunbird.workflow.utils.CassandraOperation;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
+import redis.clients.jedis.Pipeline;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -49,6 +51,10 @@ class WorkflowRedisCacheMgrTest {
         // Default: no active enrollments in Cassandra → approved = 0
         when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), anyList()))
                 .thenReturn(Collections.emptyList());
+        // Default: no wf_status rows for bulk queries
+        when(wfStatusRepo.countGroupedByStatusForApplicationIds(anyList()))
+                .thenReturn(Collections.emptyList());
+        when(configuration.getBpBatchStatsSyncRedisPipelineSize()).thenReturn(100);
     }
 
 
@@ -286,5 +292,122 @@ class WorkflowRedisCacheMgrTest {
                 "3".equals(m.get(Constants.BATCH_STATS_FIELD_APPROVED)) &&
                 "0".equals(m.get(Constants.BATCH_STATS_FIELD_PENDING))
         ));
+    }
+
+
+    @Test
+    void bulkInitBatchStats_allKeysPresent_skipsDbAndRedisWrite() {
+        List<String> batchIds = List.of("batch-A", "batch-B");
+        Pipeline checkPipeline = mock(Pipeline.class);
+        redis.clients.jedis.Response<Boolean> existsTrue = mock(redis.clients.jedis.Response.class);
+        when(existsTrue.get()).thenReturn(true);
+        when(jedis.pipelined()).thenReturn(checkPipeline);
+        when(checkPipeline.exists(anyString())).thenReturn(existsTrue);
+        cacheMgr.bulkInitBatchStats(batchIds);
+        verify(wfStatusRepo, never()).countGroupedByStatusForApplicationIds(any());
+        verify(cassandraOperation, never()).getRecordsByProperties(any(), any(), any(), any());
+        verify(checkPipeline, never()).hmset(anyString(), any());
+    }
+
+    @Test
+    void bulkInitBatchStats_allKeysMissing_withNonZeroStats_writesHmsetToRedis() {
+        List<String> batchIds = List.of("batch-A");
+        Pipeline checkPipeline = mock(Pipeline.class);
+        Pipeline writePipeline = mock(Pipeline.class);
+        redis.clients.jedis.Response<Boolean> existsFalse = mock(redis.clients.jedis.Response.class);
+        when(existsFalse.get()).thenReturn(false);
+        when(jedis.pipelined()).thenReturn(checkPipeline).thenReturn(writePipeline);
+        when(checkPipeline.exists(anyString())).thenReturn(existsFalse);
+        List<Object[]> pgRows = Collections.singletonList(new Object[]{"batch-A", "ENROLL_IS_IN_PROGRESS", 3L});
+        when(wfStatusRepo.countGroupedByStatusForApplicationIds(batchIds)).thenReturn(pgRows);
+        List<Map<String, Object>> cassRows = List.of(
+                Map.of(Constants.BATCH_ID_KEY, "batch-A", Constants.ACTIVE, true),
+                Map.of(Constants.BATCH_ID_KEY, "batch-A", Constants.ACTIVE, true)
+        );
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), anyList()))
+                .thenReturn(cassRows);
+        cacheMgr.bulkInitBatchStats(batchIds);
+        verify(writePipeline).hmset(
+                eq(Constants.BP_BATCH_STATS_PREFIX + "batch-A"),
+                argThat(m -> "3".equals(m.get(Constants.BATCH_STATS_FIELD_PENDING))
+                        && "2".equals(m.get(Constants.BATCH_STATS_FIELD_APPROVED))
+                        && "0".equals(m.get(Constants.BATCH_STATS_FIELD_WITHDRAWN))
+                        && "0".equals(m.get(Constants.BATCH_STATS_FIELD_REJECTED)))
+        );
+        verify(writePipeline).expire(eq(Constants.BP_BATCH_STATS_PREFIX + "batch-A"), anyLong());
+        verify(writePipeline).sync();
+    }
+
+    @Test
+    void bulkInitBatchStats_allZeroStats_skipsHmsetButStillSyncs() {
+        List<String> batchIds = List.of("batch-X");
+        Pipeline checkPipeline = mock(Pipeline.class);
+        Pipeline writePipeline = mock(Pipeline.class);
+        redis.clients.jedis.Response<Boolean> existsFalse = mock(redis.clients.jedis.Response.class);
+        when(existsFalse.get()).thenReturn(false);
+        when(jedis.pipelined()).thenReturn(checkPipeline).thenReturn(writePipeline);
+        when(checkPipeline.exists(anyString())).thenReturn(existsFalse);
+        cacheMgr.bulkInitBatchStats(batchIds);
+        verify(writePipeline, never()).hmset(anyString(), any());
+        verify(writePipeline).sync();
+    }
+
+    @Test
+    void bulkInitBatchStats_cassandraRowsWithNullBatchId_areFilteredFromApprovedCount() {
+        List<String> batchIds = List.of("batch-A");
+        Pipeline checkPipeline = mock(Pipeline.class);
+        Pipeline writePipeline = mock(Pipeline.class);
+        redis.clients.jedis.Response<Boolean> existsFalse = mock(redis.clients.jedis.Response.class);
+        when(existsFalse.get()).thenReturn(false);
+        when(jedis.pipelined()).thenReturn(checkPipeline).thenReturn(writePipeline);
+        when(checkPipeline.exists(anyString())).thenReturn(existsFalse);
+        when(wfStatusRepo.countGroupedByStatusForApplicationIds(batchIds))
+                .thenReturn(Collections.singletonList(new Object[]{"batch-A", "ENROLL_IS_IN_PROGRESS", 1L}));
+        Map<String, Object> rowWithNullId = new HashMap<>();
+        rowWithNullId.put(Constants.BATCH_ID_KEY, null);
+        rowWithNullId.put(Constants.ACTIVE, true);
+        List<Map<String, Object>> cassRows = List.of(
+                rowWithNullId,
+                Map.of(Constants.BATCH_ID_KEY, "batch-A", Constants.ACTIVE, true)
+        );
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), anyList()))
+                .thenReturn(cassRows);
+        cacheMgr.bulkInitBatchStats(batchIds);
+        verify(writePipeline).hmset(
+                eq(Constants.BP_BATCH_STATS_PREFIX + "batch-A"),
+                argThat(m -> "1".equals(m.get(Constants.BATCH_STATS_FIELD_APPROVED)))
+        );
+    }
+
+    @Test
+    void bulkInitBatchStats_inactiveEnrollmentsExcludedFromApprovedCount() {
+        List<String> batchIds = List.of("batch-A");
+        Pipeline checkPipeline = mock(Pipeline.class);
+        Pipeline writePipeline = mock(Pipeline.class);
+        redis.clients.jedis.Response<Boolean> existsFalse = mock(redis.clients.jedis.Response.class);
+        when(existsFalse.get()).thenReturn(false);
+        when(jedis.pipelined()).thenReturn(checkPipeline).thenReturn(writePipeline);
+        when(checkPipeline.exists(anyString())).thenReturn(existsFalse);
+        when(wfStatusRepo.countGroupedByStatusForApplicationIds(batchIds))
+                .thenReturn(Collections.singletonList(new Object[]{"batch-A", "ENROLL_IS_IN_PROGRESS", 2L}));
+        List<Map<String, Object>> cassRows = List.of(
+                Map.of(Constants.BATCH_ID_KEY, "batch-A", Constants.ACTIVE, true),
+                Map.of(Constants.BATCH_ID_KEY, "batch-A", Constants.ACTIVE, false),
+                Map.of(Constants.BATCH_ID_KEY, "batch-A", Constants.ACTIVE, false)
+        );
+        when(cassandraOperation.getRecordsByProperties(anyString(), anyString(), anyMap(), anyList()))
+                .thenReturn(cassRows);
+        cacheMgr.bulkInitBatchStats(batchIds);
+        verify(writePipeline).hmset(
+                eq(Constants.BP_BATCH_STATS_PREFIX + "batch-A"),
+                argThat(m -> "1".equals(m.get(Constants.BATCH_STATS_FIELD_APPROVED))
+                        && "2".equals(m.get(Constants.BATCH_STATS_FIELD_PENDING)))
+        );
+    }
+
+    @Test
+    void bulkInitBatchStats_doesNotThrowOnException() {
+        when(jedis.pipelined()).thenThrow(new RuntimeException("Pipeline unavailable"));
+        assertDoesNotThrow(() -> cacheMgr.bulkInitBatchStats(List.of("batch-A")));
     }
 }

--- a/src/test/java/org/sunbird/workflow/controller/BpBatchStatsSyncControllerTest.java
+++ b/src/test/java/org/sunbird/workflow/controller/BpBatchStatsSyncControllerTest.java
@@ -1,0 +1,60 @@
+package org.sunbird.workflow.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.sunbird.workflow.config.Constants;
+import org.sunbird.workflow.models.Response;
+import org.sunbird.workflow.service.BpBatchStatsSyncService;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class BpBatchStatsSyncControllerTest {
+
+    @Mock
+    private BpBatchStatsSyncService bpBatchStatsSyncService;
+
+    private BpBatchStatsSyncController controller;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        controller = new BpBatchStatsSyncController(bpBatchStatsSyncService);
+    }
+
+    @Test
+    void syncBatchCountsToRedis_delegatesToServiceAndReturnsOk() {
+        Response serviceResponse = new Response();
+        serviceResponse.put("batchesProcessed", 42);
+        serviceResponse.put(Constants.STATUS, HttpStatus.OK);
+        when(bpBatchStatsSyncService.syncBatchCountsToRedis()).thenReturn(serviceResponse);
+        ResponseEntity<Response> entity = controller.syncBatchCountsToRedis();
+        assertEquals(HttpStatus.OK, entity.getStatusCode());
+        assertNotNull(entity.getBody());
+        assertEquals(42, entity.getBody().get("batchesProcessed"));
+        verify(bpBatchStatsSyncService).syncBatchCountsToRedis();
+    }
+
+    @Test
+    void syncBatchCountsToRedis_usesHttpStatusFromServiceResponse() {
+        Response serviceResponse = new Response();
+        serviceResponse.put(Constants.STATUS, HttpStatus.INTERNAL_SERVER_ERROR);
+        when(bpBatchStatsSyncService.syncBatchCountsToRedis()).thenReturn(serviceResponse);
+        ResponseEntity<Response> entity = controller.syncBatchCountsToRedis();
+        assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, entity.getStatusCode());
+    }
+
+    @Test
+    void syncBatchCountsToRedis_zeroBatchesProcessed_stillReturnsOk() {
+        Response serviceResponse = new Response();
+        serviceResponse.put("batchesProcessed", 0);
+        serviceResponse.put(Constants.STATUS, HttpStatus.OK);
+        when(bpBatchStatsSyncService.syncBatchCountsToRedis()).thenReturn(serviceResponse);
+        ResponseEntity<Response> entity = controller.syncBatchCountsToRedis();
+        assertEquals(HttpStatus.OK, entity.getStatusCode());
+        assertEquals(0, entity.getBody().get("batchesProcessed"));
+    }
+}

--- a/src/test/java/org/sunbird/workflow/service/impl/BpBatchStatsSyncServiceImplTest.java
+++ b/src/test/java/org/sunbird/workflow/service/impl/BpBatchStatsSyncServiceImplTest.java
@@ -1,0 +1,164 @@
+package org.sunbird.workflow.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.springframework.http.HttpStatus;
+import org.sunbird.workflow.config.Configuration;
+import org.sunbird.workflow.config.Constants;
+import org.sunbird.workflow.config.WorkflowRedisCacheMgr;
+import org.sunbird.workflow.models.Response;
+import org.sunbird.workflow.service.ContentSearchService;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class BpBatchStatsSyncServiceImplTest {
+
+    @Mock
+    private ContentSearchService contentSearchService;
+
+    @Mock
+    private WorkflowRedisCacheMgr workflowRedisCacheMgr;
+
+    @Mock
+    private Configuration configuration;
+
+    @InjectMocks
+    private BpBatchStatsSyncServiceImpl syncService;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        when(configuration.getBpBatchStatsSyncDbChunkSize()).thenReturn(50);
+        when(configuration.getBpBatchStatsSyncPageSize()).thenReturn(100);
+    }
+
+    @Test
+    void syncBatchCountsToRedis_emptySearchResult_returnsZeroBatchesProcessed() {
+        when(contentSearchService.getBlendedProgramBatchDetails(anyInt(), anyInt()))
+                .thenReturn(Collections.emptyMap());
+        Response response = syncService.syncBatchCountsToRedis();
+        assertEquals(0, response.get("batchesProcessed"));
+        assertEquals(HttpStatus.OK, response.get(Constants.STATUS));
+        verify(workflowRedisCacheMgr, never()).bulkInitBatchStats(any());
+    }
+
+    @Test
+    void syncBatchCountsToRedis_singlePageWithBatches_delegatesChunkToCacheMgr() {
+        List<Map<String, Object>> programs = List.of(
+                Map.of(Constants.BATCHES, List.of(Map.of(Constants.BATCH_ID, "batch-001"))),
+                Map.of(Constants.BATCHES, List.of(Map.of(Constants.BATCH_ID, "batch-002")))
+        );
+        Map<String, Object> result = new HashMap<>();
+        result.put("count", 2);
+        result.put(Constants.CONTENT, programs);
+        when(contentSearchService.getBlendedProgramBatchDetails(100, 0)).thenReturn(result);
+        when(contentSearchService.getBlendedProgramBatchDetails(100, 100)).thenReturn(Collections.emptyMap());
+        Response response = syncService.syncBatchCountsToRedis();
+        assertEquals(2, response.get("batchesProcessed"));
+        assertEquals(HttpStatus.OK, response.get(Constants.STATUS));
+        verify(workflowRedisCacheMgr).bulkInitBatchStats(List.of("batch-001", "batch-002"));
+    }
+
+    @Test
+    void syncBatchCountsToRedis_programsWithNoBatchesField_skipsThosePrograms() {
+        List<Map<String, Object>> programs = new ArrayList<>();
+        programs.add(Map.of(Constants.BATCHES, List.of(Map.of(Constants.BATCH_ID, "batch-001"))));
+        programs.add(new HashMap<>());
+        Map<String, Object> result = new HashMap<>();
+        result.put("count", 2);
+        result.put(Constants.CONTENT, programs);
+        when(contentSearchService.getBlendedProgramBatchDetails(100, 0)).thenReturn(result);
+        when(contentSearchService.getBlendedProgramBatchDetails(100, 100)).thenReturn(Collections.emptyMap());
+        Response response = syncService.syncBatchCountsToRedis();
+        assertEquals(1, response.get("batchesProcessed"));
+        verify(workflowRedisCacheMgr).bulkInitBatchStats(List.of("batch-001"));
+    }
+
+    @Test
+    void syncBatchCountsToRedis_batchesWithNullOrBlankBatchId_filtersThemOut() {
+        Map<String, Object> batchWithNull = new HashMap<>();
+        batchWithNull.put(Constants.BATCH_ID, null);
+        Map<String, Object> batchWithBlank = new HashMap<>();
+        batchWithBlank.put(Constants.BATCH_ID, "   ");
+        List<Map<String, Object>> programs = List.of(
+                Map.of(Constants.BATCHES, Arrays.asList(
+                        batchWithNull,
+                        batchWithBlank,
+                        Map.of(Constants.BATCH_ID, "batch-valid")
+                ))
+        );
+        Map<String, Object> result = new HashMap<>();
+        result.put("count", 1);
+        result.put(Constants.CONTENT, programs);
+        when(contentSearchService.getBlendedProgramBatchDetails(100, 0)).thenReturn(result);
+        when(contentSearchService.getBlendedProgramBatchDetails(100, 100)).thenReturn(Collections.emptyMap());
+        Response response = syncService.syncBatchCountsToRedis();
+        assertEquals(1, response.get("batchesProcessed"));
+        verify(workflowRedisCacheMgr).bulkInitBatchStats(List.of("batch-valid"));
+    }
+
+    @Test
+    void syncBatchCountsToRedis_multiplePages_paginatesUntilResultsExhausted() {
+        List<Map<String, Object>> page1 = List.of(
+                Map.of(Constants.BATCHES, List.of(Map.of(Constants.BATCH_ID, "batch-P1"))),
+                Map.of(Constants.BATCHES, List.of(Map.of(Constants.BATCH_ID, "batch-P2")))
+        );
+        Map<String, Object> result1 = new HashMap<>();
+        result1.put("count", 102);
+        result1.put(Constants.CONTENT, page1);
+        List<Map<String, Object>> page2 = List.of(
+                Map.of(Constants.BATCHES, List.of(Map.of(Constants.BATCH_ID, "batch-P3")))
+        );
+        Map<String, Object> result2 = new HashMap<>();
+        result2.put("count", 102);
+        result2.put(Constants.CONTENT, page2);
+        when(contentSearchService.getBlendedProgramBatchDetails(100, 0)).thenReturn(result1);
+        when(contentSearchService.getBlendedProgramBatchDetails(100, 100)).thenReturn(result2);
+        Response response = syncService.syncBatchCountsToRedis();
+        assertEquals(3, response.get("batchesProcessed"));
+        verify(contentSearchService, times(2)).getBlendedProgramBatchDetails(anyInt(), anyInt());
+    }
+
+    @Test
+    void syncBatchCountsToRedis_chunkSize2_callsBulkInitCorrectNumberOfTimes() {
+        when(configuration.getBpBatchStatsSyncDbChunkSize()).thenReturn(2);
+        List<Map<String, Object>> programs = List.of(
+                Map.of(Constants.BATCHES, List.of(Map.of(Constants.BATCH_ID, "b1"))),
+                Map.of(Constants.BATCHES, List.of(Map.of(Constants.BATCH_ID, "b2"))),
+                Map.of(Constants.BATCHES, List.of(Map.of(Constants.BATCH_ID, "b3")))
+        );
+        Map<String, Object> result = new HashMap<>();
+        result.put("count", 3);
+        result.put(Constants.CONTENT, programs);
+        when(contentSearchService.getBlendedProgramBatchDetails(100, 0)).thenReturn(result);
+        when(contentSearchService.getBlendedProgramBatchDetails(100, 100)).thenReturn(Collections.emptyMap());
+        syncService.syncBatchCountsToRedis();
+        verify(workflowRedisCacheMgr, times(2)).bulkInitBatchStats(any());
+        verify(workflowRedisCacheMgr).bulkInitBatchStats(List.of("b1", "b2"));
+        verify(workflowRedisCacheMgr).bulkInitBatchStats(List.of("b3"));
+    }
+
+    @Test
+    void syncBatchCountsToRedis_programWithMultipleBatches_allBatchIdsCollected() {
+        List<Map<String, Object>> programs = List.of(
+                Map.of(Constants.BATCHES, List.of(
+                        Map.of(Constants.BATCH_ID, "batch-A"),
+                        Map.of(Constants.BATCH_ID, "batch-B"),
+                        Map.of(Constants.BATCH_ID, "batch-C")
+                ))
+        );
+        Map<String, Object> result = new HashMap<>();
+        result.put("count", 1);
+        result.put(Constants.CONTENT, programs);
+        when(contentSearchService.getBlendedProgramBatchDetails(100, 0)).thenReturn(result);
+        when(contentSearchService.getBlendedProgramBatchDetails(100, 100)).thenReturn(Collections.emptyMap());
+        Response response = syncService.syncBatchCountsToRedis();
+        assertEquals(3, response.get("batchesProcessed"));
+        verify(workflowRedisCacheMgr).bulkInitBatchStats(List.of("batch-A", "batch-B", "batch-C"));
+    }
+}

--- a/src/test/java/org/sunbird/workflow/service/impl/ContentSearchServiceImplTest.java
+++ b/src/test/java/org/sunbird/workflow/service/impl/ContentSearchServiceImplTest.java
@@ -1,0 +1,120 @@
+package org.sunbird.workflow.service.impl;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.*;
+import org.sunbird.workflow.config.Configuration;
+import org.sunbird.workflow.config.Constants;
+
+import java.util.*;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+class ContentSearchServiceImplTest {
+
+    @Mock
+    private Configuration configuration;
+
+    @Mock
+    private RequestServiceImpl requestServiceImpl;
+
+    private ContentSearchServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        service = new ContentSearchServiceImpl(configuration, requestServiceImpl);
+        when(configuration.getSbSearchServiceHost()).thenReturn("http://localhost:6001");
+        when(configuration.getSbCompositeV4Search()).thenReturn("/v4/search");
+    }
+
+    @Test
+    void getBlendedProgramBatchDetails_success_returnsResultMap() {
+        Map<String, Object> resultMap = new HashMap<>();
+        resultMap.put("count", 5);
+        resultMap.put(Constants.CONTENT, List.of(Map.of("identifier", "prog-1")));
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put(Constants.RESPONSE_CODE, Constants.OK);
+        responseMap.put(Constants.RESULT, resultMap);
+        when(requestServiceImpl.fetchResultUsingPost(any(), any(), eq(Map.class), isNull()))
+                .thenReturn(responseMap);
+        Map<String, Object> result = service.getBlendedProgramBatchDetails(10, 0);
+        assertFalse(result.isEmpty());
+        assertEquals(5, result.get("count"));
+    }
+
+    @Test
+    void getBlendedProgramBatchDetails_failedResponseCode_returnsEmptyMap() {
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put(Constants.RESPONSE_CODE, "ERROR");
+        when(requestServiceImpl.fetchResultUsingPost(any(), any(), eq(Map.class), isNull()))
+                .thenReturn(responseMap);
+        assertTrue(service.getBlendedProgramBatchDetails(10, 0).isEmpty());
+    }
+
+    @Test
+    void getBlendedProgramBatchDetails_nullResponse_returnsEmptyMap() {
+        when(requestServiceImpl.fetchResultUsingPost(any(), any(), eq(Map.class), isNull()))
+                .thenReturn(null);
+        assertTrue(service.getBlendedProgramBatchDetails(10, 0).isEmpty());
+    }
+
+    @Test
+    void getBlendedProgramBatchDetails_emptyResultMapInResponse_returnsEmptyMap() {
+        Map<String, Object> responseMap = new HashMap<>();
+        responseMap.put(Constants.RESPONSE_CODE, Constants.OK);
+        responseMap.put(Constants.RESULT, Collections.emptyMap());
+        when(requestServiceImpl.fetchResultUsingPost(any(), any(), eq(Map.class), isNull()))
+                .thenReturn(responseMap);
+        assertTrue(service.getBlendedProgramBatchDetails(10, 0).isEmpty());
+    }
+
+    @Test
+    void getBlendedProgramBatchDetails_exceptionThrown_returnsEmptyMap() {
+        when(requestServiceImpl.fetchResultUsingPost(any(), any(), eq(Map.class), isNull()))
+                .thenThrow(new RuntimeException("Search service down"));
+        assertTrue(service.getBlendedProgramBatchDetails(10, 0).isEmpty());
+    }
+
+    @Test
+    void getBlendedProgramBatchDetails_buildsCorrectLimitOffsetInRequestBody() {
+        when(requestServiceImpl.fetchResultUsingPost(any(), any(), eq(Map.class), isNull()))
+                .thenReturn(null);
+        service.getBlendedProgramBatchDetails(25, 50);
+        verify(requestServiceImpl).fetchResultUsingPost(
+                argThat(url -> url.toString().equals("http://localhost:6001/v4/search")),
+                argThat(body -> {
+                    Map<?, ?> req = (Map<?, ?>) ((Map<?, ?>) body).get(Constants.REQUEST);
+                    return req != null
+                            && Integer.valueOf(25).equals(req.get(Constants.LIMIT))
+                            && Integer.valueOf(50).equals(req.get(Constants.OFFSET));
+                }),
+                eq(Map.class),
+                isNull()
+        );
+    }
+
+    @Test
+    void getBlendedProgramBatchDetails_requestBodyContainsBlendedProgramFilters() {
+        when(requestServiceImpl.fetchResultUsingPost(any(), any(), eq(Map.class), isNull()))
+                .thenReturn(null);
+        service.getBlendedProgramBatchDetails(10, 0);
+        verify(requestServiceImpl).fetchResultUsingPost(
+                any(),
+                argThat(body -> {
+                    Map<?, ?> req = (Map<?, ?>) ((Map<?, ?>) body).get(Constants.REQUEST);
+                    if (req == null) return false;
+                    Map<?, ?> filters = (Map<?, ?>) req.get(Constants.FILTERS);
+                    if (filters == null) return false;
+                    boolean hasContentType = filters.containsKey(Constants.CONTENT_TYPE_FIELD);
+                    boolean hasCategory = filters.containsKey(Constants.COURSE_CATEGORY);
+                    boolean hasFields = req.containsKey(Constants.FIELDS);
+                    return hasContentType && hasCategory && hasFields;
+                }),
+                eq(Map.class),
+                isNull()
+        );
+    }
+}


### PR DESCRIPTION
feat(batch-stats): bulk Redis warm-up sync job for blended program batch enrollment stats

Implements a scheduled sync job that pre-warms Redis with enrollment stats for all live blended program batches, replacing per-request lazy-init as the primary cache fill strategy.

Core changes:
- BpBatchStatsSyncService / BpBatchStatsSyncServiceImpl: paginates all blended programs via composite search (configurable page size), collects batch IDs, partitions into DB-chunk-sized groups and delegates to WorkflowRedisCacheMgr.bulkInitBatchStats()
- ContentSearchService / ContentSearchServiceImpl: wraps composite search v4 API call for blended program + batch details with configurable host/path and typed result extraction
- BpBatchStatsSyncController: exposes POST /v1/blendedprogram/batch/stats/sync endpoint to trigger the sync manually or via scheduler
- WorkflowRedisCacheMgr.bulkInitBatchStats(): checks which keys are already live in Redis using a single pipeline EXISTS round-trip, fetches pending/withdrawn/rejected from PostgreSQL (wf_status) and approved counts from Cassandra (enrollment_batch_lookup) in one query each per chunk, and writes stats via pipelined hmset+expire; skips writing if all 4 counts are zero to avoid polluting Redis with empty hashes

Configuration (application.properties):
- bp.batch.stats.sync.db.chunk.size=50      # batches per PG+Cassandra query
- bp.batch.stats.sync.redis.pipeline.size=100  # hmset commands per pipeline flush
- bp.batch.stats.sync.page.size=100         # programs per composite search page

Tests (41 tests, BUILD SUCCESS):
- WorkflowRedisCacheMgrTest: 6 new tests covering bulk init happy path, all-keys-present skip, all-zero skip, null batchid filter, inactive enrollment filter, exception resilience
- BpBatchStatsSyncServiceImplTest: 7 tests covering pagination, chunking, null/blank batch ID filtering, no-batches-field programs, multi-page exit
- ContentSearchServiceImplTest: 7 tests covering success, error response codes, null/empty responses, exception handling, request body shape
- BpBatchStatsSyncControllerTest: 3 tests covering delegation, HTTP status propagation, zero-batches-processed case